### PR TITLE
fix nixpkgs override option

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -339,4 +339,6 @@ but instead of using the IP address, use the domain name in `./ip`.
 
 ### Add Services {#checklist-services}
 
-I do recommend using the sibling project [Self Host Blocks](https://github.com/ibizaman/selfhostblocks) to setup services like Vaultwarden, Nextcloud and others.
+I do recommend using the sibling project [SelfHostBlocks](https://github.com/ibizaman/selfhostblocks) to setup services like Vaultwarden, Nextcloud and others.
+
+The flake template is wired to use SelfHostBlocks already.

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -35,8 +35,7 @@
     skarabox.hosts = {
       myskarabox = {
         # Comment this line to use nixpkgs as the input instead of SelfHostBlocks.
-        # Note: I'm not fully convinced this line is correct and gets the patch applied.
-        nixpkgs = inputs.selfhostblocks.lib.${config.skarabox.hosts.myskarabox.system}.patchedNixpkgs.src;
+        nixpkgs = inputs.selfhostblocks.lib.${config.skarabox.hosts.myskarabox.system}.patchedNixpkgs;
         system = ./myskarabox/system;
         hostKeyPub = ./myskarabox/host_key.pub;
         ip = ./myskarabox/ip;


### PR DESCRIPTION
Now, all patches to all of nixpkgs are taken into account. Which means we can patch `nixos/modules/` code too.