### PR TITLE
Add Separated-Key Architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,11 +16,18 @@ Template:
 
 # Upcoming Release
 
+## New Features
+
+- Add separated-key architecture so that SOPS secrets, including ZFS passphrase, are protected at rest from physical access.
+- Add migration tools for existing hosts: `enable-key-separation`, `install-runtime-key`, and `rotate-boot-key`.
+- Add `runtimeHostKeyPath` and `runtimeHostKeyPub` configuration options for separated-key mode.
+
 ## Breaking Changes
 
 - Remove `hostId` file and directly set the value in the host's `configuration.nix` file.
 - Remove `ssh_port` and `ssh_boot_port` files and directly set the value in the host's `configuration.nix` file.
 - Remove `ip` and `system` files and directly set the value in the host's `flake.nix` file.
+- `gen-new-host` now creates separated-key hosts by default. Use `--single-key` flag for legacy single-key mode (existing single-key hosts remain functional).
 
 ## Fixes
 

--- a/docs/normal-operations.md
+++ b/docs/normal-operations.md
@@ -79,11 +79,93 @@ All commands are prefixed by the hostname, allowing to handle multiple hosts.
 
    and copy needed config in [flake.nix][].
 
+## Enable Key Separation {#enable-key-separation}
+
+   ::: {.warning}
+   **Security Warning:** Single-key hosts are vulnerable to physical attacks. If someone gains physical access to your server, they can extract the `/boot/host_key` and decrypt all your secrets (passwords, API keys, etc.). Enable key separation to safeguard your user data at rest.
+   :::
+
+   Upgrade existing hosts to separated-key architecture. This separates the boot key from your administrative secrets, protecting SOPS-encrypted data from physical attacks. The runtime key is stored in the encrypted ZFS pool, making it inaccessible until boot unlock. **Note:** New hosts created with `gen-new-host` use separated-key mode by default.
+
+   ```bash
+   # Generate runtime keys & update SOPS config, renaming existing key to myskarabox_boot
+   $ nix run .#myskarabox-enable-key-separation
+   # Re-encrypt secrets so that both keys can decrypt during migration
+   $ nix run .#sops -- updatekeys myskarabox/secrets.yaml
+   # Install runtime key on target
+   $ nix run .#myskarabox-install-runtime-key
+   ```
+
+   Update `myskarabox/configuration.nix` to switch SOPS to runtime key:
+   ```nix
+   sops.age.sshKeyPaths = [
+     "/persist/etc/ssh/ssh_host_ed25519_key"   # Switch from /boot/host_key
+   ];
+   ```
+
+   Update `flake.nix` to enable separated-key mode:
+   ```nix
+   skarabox.hosts.myskarabox = {
+     # ... existing config
+     runtimeHostKeyPub = ./myskarabox/runtime_host_key.pub;
+   };
+   ```
+
+   Deploy the separated-key configuration:
+   ```bash
+   $ nix run .#deploy-rs                       # Switches host to runtime key
+   $ nix run .#myskarabox-gen-knownhosts-file  # Update known_hosts after deployment
+   ```
+
+   After successful deployment, complete the migration:
+   ```bash
+   # Remove the boot key (now aliased as myskarabox_boot) from SOPS
+   $ age_key=$(nix shell nixpkgs#ssh-to-age -c ssh-to-age < myskarabox/host_key.pub)
+   $ nix run .#sops -- -r -i --rm-age "$age_key" myskarabox/secrets.yaml
+
+   # Clean up .sops.yaml by removing the boot key reference and anchor
+   $ sed -i.bak -e '/- \*myskarabox_boot$/d' -e '/&myskarabox_boot/d' .sops.yaml
+
+   # Rotate the boot key to protect against git history attacks
+   $ ssh-keygen -t ed25519 -f myskarabox/host_key -N ""
+   # See warning in rotation section, this is a destructive operation
+   $ nix run .#myskarabox-rotate-boot-key
+   $ nix run .#myskarabox-gen-knownhosts-file
+   ```
+
+   These final steps ensure secrets cannot be decrypted with the old boot key, protecting against both physical attacks and git history attacks.
+
 ## Rotate host key {#rotate-host-key}
+
+   **For single-key hosts (legacy):**
 
    ```bash
    $ ssh-keygen -f ./myskarabox/host_key
    $ nix run .#add-sops-cfg -- -o .sops.yaml alias myskarabox $(ssh-to-age -i ./myskarabox/host_key.pub)
+   $ nix run .#sops -- updatekeys ./myskarabox/secrets.yaml
+   $ nix run .#myskarabox-gen-knownhosts-file
    $ nix run .#deploy-rs
-   $ nix run .#baryum-gen-knownhosts-file
+   ```
+
+   **For separated-key hosts:**
+
+   Rotate boot key (necessary to protect against git history attack after migration):
+   
+   ::: {.warning}
+   **Destructive Operation:** This command securely wipes the boot partition with `dd + TRIM` to make key recovery difficult. The process backs up boot files to tmpfs, wipes the partition, recreates the filesystem, and reinstalls the bootloader. Requires the host to be accessible via runtime key.
+   :::
+   
+   ```bash
+   $ ssh-keygen -t ed25519 -f myskarabox/host_key -N ""
+   $ nix run .#myskarabox-rotate-boot-key
+   $ nix run .#myskarabox-gen-knownhosts-file
+   ```
+
+   Rotate runtime key (only if compromised - affects SOPS secrets):
+   ```bash
+   $ ssh-keygen -t ed25519 -N "" -f ./myskarabox/runtime_host_key
+   $ nix run .#add-sops-cfg -- -o .sops.yaml alias myskarabox $(ssh-to-age -i ./myskarabox/runtime_host_key.pub)
+   $ nix run .#sops -- updatekeys ./myskarabox/secrets.yaml
+   $ nix run .#myskarabox-gen-knownhosts-file
+   $ nix run .#deploy-rs
    ```

--- a/flake.nix
+++ b/flake.nix
@@ -69,7 +69,7 @@
         };
 
         gen-new-host = import ./lib/gen-new-host.nix {
-          inherit add-sops-cfg pkgs gen-hostId;
+          inherit pkgs add-sops-cfg gen-hostId;
           inherit (pkgs) lib;
         };
 

--- a/flakeModules/default.nix
+++ b/flakeModules/default.nix
@@ -491,6 +491,22 @@ in
               printf '%s' "$root_passphrase" | boot-ssh -T "$@"
             '';
           };
+
+          enable-key-separation = import ../lib/enable-key-separation.nix {
+            inherit pkgs name;
+            cfg = cfg';
+            add-sops-cfg = import ../lib/add-sops-cfg.nix { inherit pkgs; };
+          };
+
+          install-runtime-key = import ../lib/install-runtime-key.nix {
+            inherit pkgs ssh name;
+            cfg = cfg';
+          };
+
+          rotate-boot-key = import ../lib/rotate-boot-key.nix {
+            inherit pkgs ssh name;
+            cfg = cfg';
+          };
         in {
           "${name}-boot-ssh" = boot-ssh;
           "${name}-sops" = sops;
@@ -501,6 +517,9 @@ in
           "${name}-ssh" = ssh;
           "${name}-get-facter" = get-facter;
           "${name}-unlock" = unlock;
+          "${name}-enable-key-separation" = enable-key-separation;
+          "${name}-install-runtime-key" = install-runtime-key;
+          "${name}-rotate-boot-key" = rotate-boot-key;
         };
     in {
       packages = {

--- a/flakeModules/default.nix
+++ b/flakeModules/default.nix
@@ -59,6 +59,18 @@ in
             apply = readAsStr;
             example = lib.literalExpression "./${name}/host_key.pub";
           };
+          runtimeHostKeyPath = mkOption {
+            description = "Path from the top of the repo to the runtime ssh private file (separated-key mode only).";
+            type = types.nullOr types.str;
+            default = "${name}/runtime_host_key";
+          };
+          runtimeHostKeyPub = mkOption {
+            description = "Runtime SSH public file (separated-key mode only).";
+            type = types.nullOr (with types; oneOf [ str path ]);
+            default = null;
+            apply = v: if v == null then null else readAsStr v;
+            example = lib.literalExpression "./${name}/runtime_host_key.pub";
+          };
           ip = mkOption {
             description = ''
               IP or hostname used to ssh into the server.
@@ -340,9 +352,19 @@ in
               ssh_boot_port=${toString hostCfg.skarabox.boot.sshPort}
               host_key_pub="${cfg'.hostKeyPub}"
 
-              gen-knownhosts-file \
-                "$host_key_pub" "$ip" $ssh_port $ssh_boot_port \
-                > ${cfg'.knownHostsPath}
+              {
+                # Check if separated-key mode is configured
+                ${lib.optionalString (cfg'.runtimeHostKeyPub != null) ''
+                  runtime_key_pub="${cfg'.runtimeHostKeyPub}"
+                  gen-knownhosts-file "$host_key_pub" "$ip" $ssh_boot_port
+                  gen-knownhosts-file "$runtime_key_pub" "$ip" $ssh_port
+                ''}
+
+                # Single key mode (backward compatibility)
+                ${lib.optionalString (cfg'.runtimeHostKeyPub == null) ''
+                  gen-knownhosts-file "$host_key_pub" "$ip" $ssh_port $ssh_boot_port
+                ''}
+              } > ${cfg'.knownHostsPath}
             '';
           };
 
@@ -400,7 +422,8 @@ in
                   ++ [ "--ssh-option" "ConnectTimeout=10" ]
                   ++ (lib.optionals (cfg'.sshPrivateKeyPath != null) [ "-i" cfg'.sshPrivateKeyPath ])
                   ++ [ "--disk-encryption-keys" "/tmp/host_key" cfg'.hostKeyPath ]
-                  ++ (lib.flatten (mapAttrsToList (name: path: [ "--disk-encryption-keys" "/tmp/${name}" "\$secret_file_${name}" ]) secrets));
+                  ++ (lib.flatten (mapAttrsToList (name: path: [ "--disk-encryption-keys" "/tmp/${name}" "\$secret_file_${name}" ]) secrets))
+                  ++ (lib.optionals (cfg'.runtimeHostKeyPub != null) [ "--disk-encryption-keys" "/tmp/runtime_host_key" cfg'.runtimeHostKeyPath ]);
                 
                 # Convert to a bash array declaration
                 argsString = concatStringsSep " " (map (arg: ''"${arg}"'') extraArgs);

--- a/lib/enable-key-separation.nix
+++ b/lib/enable-key-separation.nix
@@ -1,0 +1,200 @@
+{
+  pkgs,
+  name,
+  cfg,
+  add-sops-cfg,
+}:
+pkgs.writeShellApplication {
+  name = "enable-key-separation";
+
+  runtimeInputs = [
+    pkgs.openssh
+    pkgs.yq-go
+    pkgs.ssh-to-age
+    add-sops-cfg
+  ];
+
+  text = ''
+    set -euo pipefail
+
+    # From flake configuration
+    hostname="${name}"
+    boot_key_pub="${cfg.hostKeyPub}"
+    runtime_key="${cfg.runtimeHostKeyPath}"
+    runtime_key_pub="''${runtime_key}.pub"
+    sops_file="${cfg.secretsFilePath}"
+    sops_cfg=".sops.yaml"
+
+    usage () {
+      cat <<USAGE
+Usage: $0 [-h]
+
+Generates runtime keys and updates SOPS configuration for separated-key migration.
+
+  -h: Shows this usage
+
+Note: Must be run from the flake root directory.
+USAGE
+    }
+
+    while getopts "h" o; do
+      case "''${o}" in
+        h)
+          usage
+          exit 0
+          ;;
+        *)
+          usage
+          exit 1
+          ;;
+      esac
+    done
+    shift $((OPTIND-1))
+
+    validate_prerequisites () {
+      # Validate SOPS configuration exists
+      if [ ! -f "$sops_cfg" ]; then
+        echo "Error: SOPS configuration not found: $sops_cfg" >&2
+        exit 1
+      fi
+
+      # Validate secrets file exists
+      if [ ! -f "$sops_file" ]; then
+        echo "Error: SOPS secrets file not found: $sops_file" >&2
+        exit 1
+      fi
+    }
+
+    generate_runtime_key () {
+      if [ -f "$runtime_key" ] && [ -f "$runtime_key_pub" ]; then
+        echo "[1/6] Runtime SSH key already exists, skipping generation"
+        return 0
+      fi
+
+      echo "[1/6] Generating runtime SSH key pair for $hostname..."
+      ssh-keygen -t ed25519 -N "" -f "$runtime_key" -C "runtime-key@$hostname"
+      chmod 600 "$runtime_key"
+      chmod 644 "$runtime_key_pub"
+      echo "Generated runtime SSH key: $runtime_key"
+    }
+
+    get_age_keys () {
+      echo "[2/6] Converting SSH keys to Age format..."
+
+      boot_age_key=$(echo "$boot_key_pub" | ssh-to-age 2>/dev/null)
+      runtime_age_key=$(ssh-to-age < "$runtime_key_pub" 2>/dev/null)
+
+      if [ -z "$boot_age_key" ] || [ -z "$runtime_age_key" ]; then
+        echo "Error: Failed to convert SSH keys to Age format" >&2
+        exit 1
+      fi
+
+      echo "Boot Age key: $boot_age_key"
+      echo "Runtime Age key: $runtime_age_key"
+    }
+
+    update_sops_config () {
+      echo "[3/6] Updating SOPS configuration..."
+
+      cp "$sops_cfg" "$sops_cfg.bak.$(date +%s)"
+
+      # Check if runtime key already exists in config
+      if grep -q "$runtime_age_key" "$sops_cfg" 2>/dev/null; then
+        echo "Runtime key already in SOPS config, skipping update"
+        return 0
+      fi
+
+      # Check for inconsistent state - boot key already renamed but no runtime key
+      local boot_renamed_count
+      boot_renamed_count=$(yq eval "[.keys.[] | select(anchor == \"''${hostname}_boot\")] | length" "$sops_cfg" 2>/dev/null || echo "0")
+      if [ "$boot_renamed_count" -gt 0 ]; then
+        echo "Error: .sops.yaml is in an inconsistent state" >&2
+        echo "Found ''${hostname}_boot anchor but no runtime key" >&2
+        echo "" >&2
+        echo "This usually means a previous migration attempt was interrupted." >&2
+        echo "To fix:" >&2
+        echo "  1. Restore from backup: cp .sops.yaml.bak.* .sops.yaml" >&2
+        echo "  2. Or manually edit .sops.yaml to rename ''${hostname}_boot back to $hostname" >&2
+        echo "  3. Then re-run this script" >&2
+        exit 1
+      fi
+
+      # Check if boot key exists with original name (expected state)
+      local boot_key_count
+      boot_key_count=$(yq eval "[.keys.[] | select(anchor == \"$hostname\")] | length" "$sops_cfg" 2>/dev/null || echo "0")
+      if [ "$boot_key_count" -eq 0 ]; then
+        echo "Error: Boot key with anchor '$hostname' not found in .sops.yaml" >&2
+        echo "Cannot proceed with migration - expected to find original boot key" >&2
+        exit 1
+      fi
+
+      # Everything looks good, rename the boot key
+      echo "Renaming boot host key alias to ''${hostname}_boot..."
+      yq eval -i \
+        "(.keys.[] | select(anchor == \"$hostname\")) anchor = \"''${hostname}_boot\" |
+         (.. | select(alias == \"$hostname\")) alias = \"''${hostname}_boot\"" \
+        "$sops_cfg"
+
+      # Add runtime key as primary $hostname alias
+      echo "Adding runtime host key as $hostname..."
+      if ! add-sops-cfg -o "$sops_cfg" alias "$hostname" "$runtime_age_key"; then
+        echo "Error: Failed to add runtime key alias to SOPS configuration" >&2
+        exit 1
+      fi
+
+      # Add the runtime key to the path regex rules
+      if ! add-sops-cfg -o "$sops_cfg" path-regex "$hostname" "$sops_file"; then
+        echo "Error: Failed to add runtime key to path regex rules" >&2
+        exit 1
+      fi
+
+      echo "Updated SOPS configuration with both keys"
+    }
+
+    # Note: Secrets re-encryption is now a manual step
+  # The script will guide the user after completing the automated steps
+
+    show_migration_status () {
+      echo ""
+      echo "[4/4] Migration Preparation Complete"
+      echo ""
+      echo "Files updated:"
+      echo "  $runtime_key"
+      echo "  $runtime_key_pub"
+      echo "  $sops_cfg"
+
+      echo ""
+      echo "Next steps:"
+      echo " 1. Re-encrypt secrets:"
+      echo "      nix run .#sops -- updatekeys $sops_file"
+      echo ""
+      echo " 2. Install runtime key on target:"
+      echo "      nix run .#$hostname-install-runtime-key"
+      echo ""
+      echo " 3. Update configuration.nix SOPS path:"
+      echo "      sshKeyPaths = [\"/persist/etc/ssh/ssh_host_ed25519_key\"];"
+      echo ""
+      echo " 4. Update flake.nix:"
+      echo "      runtimeHostKeyPub = ./$hostname/runtime_host_key.pub;"
+      echo ""
+      echo " 5. Deploy and regenerate known_hosts:"
+      echo "      nix run .#deploy-rs"
+      echo "      nix run .#$hostname-gen-knownhosts-file"
+      echo ""
+    }
+
+    main () {
+      echo "Preparing $hostname for separated-key migration..."
+
+      validate_prerequisites
+
+      generate_runtime_key
+      get_age_keys
+      update_sops_config
+
+      show_migration_status
+    }
+
+    main
+  '';
+}

--- a/lib/gen-initial.nix
+++ b/lib/gen-initial.nix
@@ -130,7 +130,7 @@ USAGE
     e "Creating initial SOPS config in $sops_cfg..."
     rm $sops_cfg && sops-add-main-key $sops_key $sops_cfg
 
-    e "Now, we will generate the secrets for myskarabox."
+    e "Now, we will generate the secrets for $name."
 
     rm -rf myskarabox
     # We force yes because if we came to here, we said yes earlier.

--- a/lib/gen-knownhosts-file.nix
+++ b/lib/gen-knownhosts-file.nix
@@ -16,8 +16,12 @@ pkgs.writeShellScriptBin "gen-knownhosts-file" ''
   ip=$1
   shift
 
-  echo "$ip $pub"
   for port in "$@"; do
-    echo "[$ip]:$port $pub"
+    if [ "$port" = "22" ]; then
+      # Port 22 is the default, so omit the port specification
+      echo "$ip $pub"
+    else
+      echo "[$ip]:$port $pub"
+    fi
   done
 ''

--- a/lib/gen-new-host.nix
+++ b/lib/gen-new-host.nix
@@ -25,10 +25,12 @@ pkgs.writeShellApplication {
     yes=0
     mkpasswdargs=
     verbose=
+    hostname=         # Initialize hostname variable
+    separated_keys=1  # Default to separated-key architecture for new hosts (better security)
 
     usage () {
       cat <<USAGE
-Usage: $0 [-h] [-y] [-s] [-v] -n HOSTNAME
+Usage: $0 [-h] [-y] [-s] [-v] [--single-key] -n HOSTNAME
 
   The only required argument, HOSTNAME, is the hostname
   you want to give to the new host. It will also be used
@@ -40,10 +42,17 @@ Usage: $0 [-h] [-y] [-s] [-v] -n HOSTNAME
              in scripts.
   -v:        Shows what commands are being run.
   -n:        Generate files for this hostname.
+
+  Advanced options:
+  --single-key: Use legacy single-key mode (less secure).
+             Creates only one key used for both boot unlock and
+             administrative access. Key stored unencrypted on /boot
+             partition enables SOPS secret compromise via physical access.
+             Consider separated-key mode (default) for better security.
 USAGE
     }
 
-    while getopts "hynsv" o; do
+    while getopts "hysv-:n:" o; do
       case "''${o}" in
         h)
           usage
@@ -58,6 +67,21 @@ USAGE
         v)
           verbose=1
           ;;
+        n)
+          hostname="''${OPTARG}"
+          ;;
+        -)
+          case "''${OPTARG}" in
+            single-key)
+              separated_keys=0
+              ;;
+            *)
+              echo "Unknown option: --''${OPTARG}" >&2
+              usage
+              exit 1
+              ;;
+          esac
+          ;;
         *)
           usage
           exit 1
@@ -66,7 +90,11 @@ USAGE
     done
     shift $((OPTIND-1))
 
-    hostname=$1
+    # If hostname wasn't set via -n flag, try to get it from positional argument
+    if [ -z "$hostname" ]; then
+      hostname=$1
+    fi
+
     if [ -z "$hostname" ]; then
       echo "Please give a hostname. Add -h for usage."
       exit 1
@@ -108,14 +136,37 @@ USAGE
     mkdir -p "$hostname"
 
     configuration="$hostname/configuration.nix"
-    e "Generating $configuration"
+    e "[1/5] Generating $configuration"
     cp ${../template/myskarabox/configuration.nix} "$configuration"
-    sed -i "s/myskarabox/$hostname/" "$configuration"
+    sed -i "s/myskarabox/$hostname/g" "$configuration"
 
+    # Template is configured for separated-key mode by default
+    # Only patch for single-key mode if requested
+    if [ "$separated_keys" -eq 0 ]; then
+      # Patch SOPS to use boot key instead of runtime key
+      sed -i 's|/persist/etc/ssh/ssh_host_ed25519_key|/boot/host_key|' "$hostname/configuration.nix"
+
+      # Update comment to reflect single-key mode (preserving indentation)
+      sed -i 's/# Separated-key mode:.*/# Single-key mode (legacy - less secure)/' "$hostname/configuration.nix"
+
+      e "Warning: Configuration uses legacy single-key mode (less secure)"
+    else
+      e "Configuration uses separated-key mode (enhanced security - OpenSSH standard path)"
+    fi
+
+    e "[2/5] Generating host keys and admin SSH key"
     host_key="./$hostname/host_key"
     host_key_pub="$host_key.pub"
     e "Generating server host key in $host_key and $host_key.pub..."
     ssh-keygen -t ed25519 -N "" -f "$host_key" && chmod 600 "$host_key"
+
+    # Generate runtime key if separated keys enabled
+    if [ "$separated_keys" -eq 1 ]; then
+      runtime_key="./$hostname/runtime_host_key"
+      runtime_key_pub="$runtime_key.pub"
+      e "Generating runtime host key in $runtime_key and $runtime_key.pub..."
+      ssh-keygen -t ed25519 -N "" -f "$runtime_key" && chmod 600 "$runtime_key"
+    fi
 
     ssh_key="./$hostname/ssh"
     e "Generating ssh key in $ssh_key and $ssh_key.pub..."
@@ -124,14 +175,26 @@ USAGE
     e "Generating hostid..."
     sed -i "s/\(skarabox.hostId =\) null;/\1 \"$(${lib.getExe gen-hostId})\";/" "$configuration"
 
+    e "[3/5] Configuring SOPS encryption"
     sops_cfg="./.sops.yaml"
     secrets="$hostname/secrets.yaml"
     e "Adding host key in $sops_cfg..."
-    host_age_key="$(ssh-to-age -i "$host_key_pub")"
+
+    # Use runtime key for SOPS if separated keys enabled, otherwise use boot key
+    if [ "$separated_keys" -eq 1 ]; then
+      sops_key_pub="$runtime_key_pub"
+      e "Using secure runtime key for SOPS encryption (separated-key mode)"
+    else
+      sops_key_pub="$host_key_pub"
+      e "Using boot host key for SOPS encryption (single-key mode)"
+    fi
+
+    host_age_key="$(ssh-to-age -i "$sops_key_pub")"
     add-sops-cfg -o "$sops_cfg" alias "$hostname" "$host_age_key"
     add-sops-cfg -o "$sops_cfg" path-regex main "$secrets"
     add-sops-cfg -o "$sops_cfg" path-regex "$hostname" "$secrets"
 
+    e "[4/5] Initializing secrets"
     sops_key="./sops.key"
     export SOPS_AGE_KEY_FILE=$sops_key
     e "Generating sops secrets file $secrets..."
@@ -156,6 +219,7 @@ USAGE
     sops unset "$secrets" \
       "['tmp_secret']"
 
+    e "[5/5] Setup complete - next steps"
     e "You will need to set the 'skarabox.hosts.<name>.ip' and 'skarabox.hosts.<name>.system' options in 'flake.nix' then generate ./$hostname/known_hosts."
     e "Optionally, adjust the 'skarabox.sshPort' and 'skarabox.boot.sshPort' in options in '$configuration' if you want to."
     e "Follow the ./README.md for more information and to continue the installation."

--- a/lib/install-runtime-key.nix
+++ b/lib/install-runtime-key.nix
@@ -1,0 +1,85 @@
+{
+  pkgs,
+  name,
+  cfg,
+  ssh,
+}:
+pkgs.writeShellApplication {
+  name = "install-runtime-key";
+
+  runtimeInputs = [
+    ssh
+  ];
+
+  text = ''
+    set -euo pipefail
+
+    hostname="${name}"
+    runtime_key_path="${cfg.runtimeHostKeyPath}"
+
+    usage () {
+      cat <<USAGE
+Usage: $0 [-h]
+
+Copies runtime key to target host in preparation for separated-key migration.
+
+  -h: Shows this usage
+
+Prerequisites: nix run .#${name}-enable-key-separation
+USAGE
+    }
+
+    while getopts "h" o; do
+      case "''${o}" in
+        h)
+          usage
+          exit 0
+          ;;
+        *)
+          usage
+          exit 1
+          ;;
+      esac
+    done
+    shift $((OPTIND-1))
+
+    # Validate prerequisites
+    echo "Validating prerequisites for $hostname..."
+
+    if [ ! -f "$runtime_key_path" ]; then
+      echo "Error: Runtime key not found at: $runtime_key_path" >&2
+      echo "Run enable-key-separation first:" >&2
+      echo " nix run .#$hostname-enable-key-separation" >&2
+      exit 1
+    fi
+
+    echo "Prerequisites validated"
+
+    # Install runtime private key directly to final location on target host
+    echo "Installing runtime key to $hostname..."
+
+    # Stream key directly via SSH stdin to avoid tmp file exposure
+    cat $runtime_key_path | ssh "sudo install -D -m 600 /dev/stdin /persist/etc/ssh/ssh_host_ed25519_key"
+
+    echo "Runtime key installed at /persist/etc/ssh/ssh_host_ed25519_key on $hostname"
+    echo ""
+    echo "Next steps:"
+    echo " 1. Update $hostname/configuration.nix:"
+    echo "      sops.age.sshKeyPaths = [ \"/persist/etc/ssh/ssh_host_ed25519_key\" ];"
+    echo ""
+    echo " 2. Update flake.nix:"
+    echo "      runtimeHostKeyPub = ./$hostname/runtime_host_key.pub;"
+    echo ""
+    echo " 3. Deploy:"
+    echo "      nix run .#deploy-rs"
+    echo "      nix run .#$hostname-gen-knownhosts-file"
+    echo ""
+    echo " 4. After deployment, complete migration:"
+    echo "      age_key=\$(ssh-to-age < $hostname/host_key.pub)"
+    echo "      nix run .#sops -- -r -i --rm-age \"\$age_key\" $hostname/secrets.yaml"
+    echo "      sed -i.bak -e '/- \*''${hostname}_boot\$/d' -e '/&''${hostname}_boot/d' .sops.yaml"
+    echo "      ssh-keygen -t ed25519 -f $hostname/host_key"
+    echo "      nix run .#$hostname-rotate-boot-key"
+    echo "      nix run .#$hostname-gen-knownhosts-file"
+  '';
+}

--- a/lib/rotate-boot-key.nix
+++ b/lib/rotate-boot-key.nix
@@ -1,0 +1,261 @@
+{
+  pkgs,
+  name,
+  cfg,
+  ssh,
+}:
+pkgs.writeShellApplication {
+  name = "rotate-boot-key";
+
+  runtimeInputs = [
+    ssh
+    pkgs.openssh     # ssh-keygen
+    pkgs.coreutils   # cat
+  ];
+
+  text = ''
+    set -euo pipefail
+
+    # From flake configuration
+    hostname="${name}"
+    private_key_path="${cfg.hostKeyPath}"
+
+    usage () {
+      cat <<USAGE
+Usage: $0 [-h]
+
+Rotates the boot SSH key with secure partition wipe for host: ${name}
+
+WARNING: Destructive operation - wipes boot partition with dd + TRIM.
+Old key becomes unrecoverable after block-level overwrite.
+
+Process:
+  1. Backup /boot to tmpfs
+  2. Unmount and securely wipe partition (dd + TRIM/discard)
+  3. Recreate filesystem and restore boot files with new key
+  4. Reinstall bootloader
+  5. Handle mirrored boot partitions if present
+
+Prerequisites:
+  - Must run after deploying separated-key configuration
+  - Target host must be reachable via runtime SSH key
+
+Options:
+  -h: Shows this usage
+USAGE
+    }
+
+    while getopts "h" o; do
+      case "''${o}" in
+        h)
+          usage
+          exit 0
+          ;;
+        *)
+          usage
+          exit 1
+          ;;
+      esac
+    done
+    shift $((OPTIND-1))
+
+    # Validate
+    if [ ! -f "$private_key_path" ]; then
+      echo "Error: $private_key_path not found" >&2
+      exit 1
+    fi
+
+    # https://stackoverflow.com/a/29436423/1013628
+    yes_or_no () {
+      while true; do
+        echo -ne "\e[1;31mWARNING:\e[0m "
+        read -rp "$* [y/N]: " yn
+        case $yn in
+          [Yy]*) return 0 ;;
+          [Nn]*|"") echo "Aborted." ; exit 0 ;;
+        esac
+      done
+    }
+
+    # Show fingerprints
+    echo "Boot SSH Key Rotation for $hostname"
+    echo "===================================="
+    echo ""
+    old_key_fp=$(ssh "sudo ssh-keygen -l -f /boot/host_key")
+    new_key_fp=$(ssh-keygen -l -f "$private_key_path")
+
+    echo "Old key: $old_key_fp"
+    echo "New key: $new_key_fp"
+    echo ""
+
+    # Validate keys are different
+    if [ "$old_key_fp" = "$new_key_fp" ]; then
+      echo "❌ ERROR: Old and new keys are identical!" >&2
+      echo "" >&2
+      echo "You must generate a new key before rotating:" >&2
+      echo "  ssh-keygen -t ed25519 -f $private_key_path -N \"\"" >&2
+      echo "" >&2
+      exit 1
+    fi
+
+    echo "This will:"
+    echo " 1. Backup /boot contents to tmpfs"
+    echo " 2. Securely wipe the boot partition (dd + TRIM/discard)"
+    echo " 3. Recreate the filesystem"
+    echo " 4. Restore boot files with new SSH key"
+    echo " 5. Reinstall bootloader"
+    echo ""
+    echo "⚠️  DESTRUCTIVE: Old key will be unrecoverable (block-level wipe)"
+    echo ""
+    yes_or_no "Continue with rotation?"
+
+    # Remote script - uses system tools already on NixOS
+    echo ""
+    echo "Running rotation on remote system..."
+    echo ""
+
+    # Read the private key content
+    private_key_content=$(cat "$private_key_path")
+
+    # Execute remote script with key embedded
+    # shellcheck disable=SC2087
+    ssh bash <<REMOTE_SCRIPT
+      set -euo pipefail
+
+      # Private key content embedded in script
+      private_key_content='$private_key_content'
+
+      # Discover current boot partition configuration
+      echo "[1/8] Discovering current partition layout..."
+      boot_dev=\$(findmnt -n -o SOURCE /boot)
+      boot_fstype=\$(lsblk -ndo FSTYPE "\$boot_dev")
+      boot_label=\$(lsblk -ndo LABEL "\$boot_dev" || echo "")
+      boot_mount_opts=\$(findmnt -n -o OPTIONS /boot)
+
+      # Check for mirrored boot
+      if findmnt /boot-backup &>/dev/null; then
+        has_backup=1
+        backup_dev=\$(findmnt -n -o SOURCE /boot-backup)
+        echo "     Found mirrored boot: \$backup_dev"
+      else
+        has_backup=0
+      fi
+
+      echo "     Device: \$boot_dev"
+      echo "     Filesystem: \$boot_fstype"
+      echo "     Label: \''${boot_label:-<none>}"
+      echo "     Mount options: \$boot_mount_opts"
+
+      # Validate it's vfat (we only handle FAT filesystems)
+      if [ "\$boot_fstype" != "vfat" ]; then
+        echo "Error: Expected vfat filesystem, found \$boot_fstype" >&2
+        exit 1
+      fi
+
+      # Backup boot contents
+      echo ""
+      echo "[2/8] Backing up boot files to tmpfs..."
+      mkdir -p /tmp/boot-backup
+      sudo rsync -a /boot/ /tmp/boot-backup/ --exclude=host_key
+      echo "     \$(du -sh /tmp/boot-backup | cut -f1) backed up"
+
+      # Unmount and wipe
+      echo ""
+      echo "[3/8] Unmounting /boot..."
+      sudo umount /boot
+
+      echo ""
+      echo "[4/8] Securely wiping \$boot_dev (this may take a moment)..."
+      sudo dd if=/dev/zero of="\$boot_dev" bs=1M status=progress 2>&1 || true
+      echo "     → Block-level wipe complete"
+
+      # Issue TRIM/discard for SSDs (helps with wear-leveling)
+      if command -v blkdiscard >/dev/null 2>&1; then
+        echo "     → Issuing TRIM/discard..."
+        sudo blkdiscard "\$boot_dev" 2>&1 || echo "     → (TRIM not supported, skipping)"
+      fi
+
+      # Recreate filesystem with discovered parameters
+      echo ""
+      echo "[5/8] Recreating filesystem..."
+      if [ -n "\$boot_label" ]; then
+        sudo mkfs.vfat -F 32 -n "\$boot_label" "\$boot_dev"
+      else
+        sudo mkfs.vfat -F 32 "\$boot_dev"
+      fi
+
+      # Mount with discovered options
+      echo "     Mounting..."
+      sudo mount -o "\$boot_mount_opts" "\$boot_dev" /boot
+
+      # Restore and install new key
+      echo ""
+      echo "[6/8] Restoring boot files and installing new key..."
+      sudo rsync -a /tmp/boot-backup/ /boot/
+      echo "\$private_key_content" | sudo install -m 600 /dev/stdin /boot/host_key
+      echo "     New key installed"
+
+      # Handle mirrored boot
+      if [ "\$has_backup" -eq 1 ]; then
+        echo "     → Processing mirrored boot partition..."
+        sudo umount /boot-backup
+        sudo dd if=/dev/zero of="\$backup_dev" bs=1M status=progress 2>&1 || true
+        if command -v blkdiscard >/dev/null 2>&1; then
+          sudo blkdiscard "\$backup_dev" 2>&1 || true
+        fi
+        if [ -n "\$boot_label" ]; then
+          sudo mkfs.vfat -F 32 -n "\$boot_label" "\$backup_dev"
+        else
+          sudo mkfs.vfat -F 32 "\$backup_dev"
+        fi
+        sudo mount -o "\$boot_mount_opts" "\$backup_dev" /boot-backup
+        sudo rsync -a /tmp/boot-backup/ /boot-backup/
+        echo "\$private_key_content" | sudo install -m 600 /dev/stdin /boot-backup/host_key
+        echo "     → Mirror synchronized"
+      fi
+
+      # Reinstall bootloader using the system's current bootloader configuration
+      echo ""
+      echo "[7/8] Reinstalling bootloader..."
+      if [ -x "/run/current-system/bin/switch-to-configuration" ]; then
+        sudo /run/current-system/bin/switch-to-configuration boot || {
+          echo "     Warning: Bootloader reinstall may have failed, but boot contents are restored"
+        }
+      else
+        echo "     Warning: Could not find bootloader installer, boot files restored but EFI may need manual update"
+      fi
+
+      echo ""
+      echo "[8/8] Cleaning up..."
+      sudo rm -rf /tmp/boot-backup
+
+      echo ""
+      echo "Rotation complete!"
+REMOTE_SCRIPT
+
+    # Verify
+    echo ""
+    echo "Verification"
+    echo "============"
+    actual_fp=$(ssh "sudo ssh-keygen -l -f /boot/host_key")
+    expected_fp=$(ssh-keygen -l -f "$private_key_path")
+    echo "Expected: $expected_fp"
+    echo "Actual:   $actual_fp"
+
+    if [ "$expected_fp" = "$actual_fp" ]; then
+      echo "Key rotation verified successfully"
+    else
+      echo "Warning: Key fingerprints do not match!" >&2
+      exit 1
+    fi
+
+    echo ""
+    echo "Next steps:"
+    echo " 1. Update known_hosts:"
+    echo "      nix run .#${name}-gen-knownhosts-file"
+    echo ""
+    echo " 2. Reboot to activate:"
+    echo "      nix run .#${name}-ssh sudo reboot"
+    echo ""
+  '';
+}

--- a/modules/configuration.nix
+++ b/modules/configuration.nix
@@ -133,9 +133,24 @@ in
       '';
       apply = readAsStr;
     };
+
+    useSeparatedKeys = mkOption {
+      type = types.bool;
+      default = false;
+      description = ''
+        Enable separated-key architecture with distinct boot and runtime SSH keys.
+        When disabled, uses single-key architecture (less secure, for backward compatibility).
+      '';
+    };
   };
 
-  config = {
+  config = let
+    # Standard path for runtime host key in separated-key mode
+    runtimeKeyPath = "/persist/etc/ssh/ssh_host_ed25519_key";
+    
+    # Auto-detect separated-key mode: check if SOPS uses the standard runtime key path
+    isSeparatedMode = cfg.useSeparatedKeys || builtins.elem runtimeKeyPath (config.sops.age.sshKeyPaths or []);
+  in {
     assertions = [
       {
         assertion = cfg.staticNetwork == null -> config.boot.initrd.network.udhcpc.enable;
@@ -143,6 +158,30 @@ in
           If DHCP is disabled and an IP is not set, the box will not be reachable through the network on boot and you will not be able to enter the passphrase through SSH.
 
           To fix this error, either set config.boot.initrd.network.udhcpc.enable = true or give an IP to skarabox.staticNetwork.ip.
+        '';
+      }
+      {
+        assertion = !isSeparatedMode || builtins.elem runtimeKeyPath (config.sops.age.sshKeyPaths or []);
+        message = ''
+          Skarabox separated-key mode requires runtime key at standard location.
+
+          Expected: ${runtimeKeyPath}
+          Found in sops.age.sshKeyPaths: ${lib.concatStringsSep ", " (config.sops.age.sshKeyPaths or ["(none configured)"])}
+
+          Please configure:
+            sops.age.sshKeyPaths = ["${runtimeKeyPath}"];
+        '';
+      }
+      {
+        assertion = config.services.openssh.hostKeys == [];
+        message = ''
+          Skarabox manages SSH host keys explicitly.
+          Do not override services.openssh.hostKeys.
+
+          Current value: ${builtins.toJSON config.services.openssh.hostKeys}
+          Expected: []
+
+          Skarabox configures the host key via extraConfig.
         '';
       }
     ];
@@ -226,10 +265,30 @@ in
       };
       ports = [ cfg.sshPort ];
       hostKeys = lib.mkForce [];
-      extraConfig = ''
-        HostKey /boot/host_key
-      '';
+      extraConfig = lib.mkAfter (
+        if isSeparatedMode
+        then ''
+          HostKey ${runtimeKeyPath}
+        ''
+        else ''
+          HostKey /boot/host_key
+        ''
+      );
     };
+
+    systemd.tmpfiles.rules = lib.optionals isSeparatedMode [
+      # Ensure directory exists before SSH tries to use the runtime key
+      "d /persist/etc/ssh 0755 root root -"
+    ];
+
+    warnings = lib.optionals (!isSeparatedMode) [
+      ''
+        Skarabox: Using single-key architecture (vulnerable to physical access)
+
+        All secrets can be decrypted by anyone with physical access to /boot partition.
+        Consider migrating to separated-key mode for better security.
+      ''
+    ];
 
     system.stateVersion = "23.11";
   };

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -42,6 +42,9 @@
         nixpkgs = inputs.selfhostblocks.lib.${config.skarabox.hosts.myskarabox.system}.patchedNixpkgs;
         system = "x86_64-linux";
         hostKeyPub = ./myskarabox/host_key.pub;
+        runtimeHostKeyPub = ./myskarabox/runtime_host_key.pub;
+        # Single-key mode: Remove runtimeHostKeyPub above for single key at /boot/host_key
+
         ip = "192.168.1.30";
         sshAuthorizedKey = ./myskarabox/ssh.pub;
         knownHosts = ./myskarabox/known_hosts;

--- a/template/myskarabox/configuration.nix
+++ b/template/myskarabox/configuration.nix
@@ -53,7 +53,8 @@ in
 
       sops.defaultSopsFile = ./secrets.yaml;
       sops.age = {
-        sshKeyPaths = [ "/boot/host_key" ];
+        # Separated-key mode: SOPS uses secure runtime key
+        sshKeyPaths = ["/persist/etc/ssh/ssh_host_ed25519_key"];
       };
 
       sops.secrets."myskarabox/user/hashedPassword" = {


### PR DESCRIPTION
## Overview

This PR introduces a **separated-key architecture** that protects SOPS-encrypted secrets (including ZFS passphrase, passwords, API keys) from physical access attacks. By separating the boot SSH key from the runtime SSH key used for SOPS decryption, an attacker with physical access to the unencrypted `/boot` partition can no longer decrypt your secrets.

**New hosts created with `gen-new-host` now use separated-key mode by default.** Migration tools are provided for upgrading existing single-key hosts.

## Security Model

### The Problem: Single-Key Vulnerability

In traditional single-key mode, one SSH key (`/boot/host_key`) serves two purposes:
1. **Initrd SSH**: SSH into initrd to decrypt ZFS root pool
2. **SOPS decryption**: Decrypt secrets for system operation

Since `/boot` must be unencrypted, this creates a vulnerability:
- 🔓 Physical access to drive → Can read `/boot/host_key`
- 🔓 With boot key → Can decrypt all SOPS secrets (ZFS passphrase, passwords, API keys)
- 🔓 With secrets → Full system compromise, even while powered off

### The Solution: Separated-Key Architecture

**Boot key** (`/boot/host_key`):
- Purpose: SSH host key for initrd environment only
- Location: Unencrypted `/boot` partition (required for remote decrypt)
- Security: Physical access = SSH MITM possible, but **data remains safe at rest**

**Runtime key** (`/persist/etc/ssh/ssh_host_ed25519_key`):
- Purpose: SSH host key for normal system + SOPS secrets decryption
- Location: **Encrypted** on ZFS pool in `/persist`
- Security: Physical access = **cannot decrypt secrets** without boot unlock

### Configuration Modes

**Single-key (legacy, discouraged):**
```nix
sops.age.sshKeyPaths = ["/boot/host_key"];
```

**Separated-key (default, recommended):**
```nix
sops.age.sshKeyPaths = ["/persist/etc/ssh/ssh_host_ed25519_key"];
```

## Core Implementation

### Automatic Detection
Skarabox automatically detects separated-key mode when the runtime key path (`/persist/etc/ssh/ssh_host_ed25519_key`) is configured in `sops.age.sshKeyPaths`.

### New Configuration Options
- `skarabox.runtimeHostKeyPath` - Path to runtime private key (default: `"${hostDir}/runtime_host_key"`)
- `skarabox.runtimeHostKeyPub` - Runtime public key content

### Key Installation
During system installation (`install-on-beacon`), the runtime key is:
1. Passed via `--disk-encryption-keys` to disko
2. Installed to `/persist/etc/ssh/ssh_host_ed25519_key` in disko's `postMountHook`
3. Configured for OpenSSH via `services.openssh.hostKeys`

### Boot Dependency
`/persist` is marked as `neededForBoot` to ensure SOPS can access the runtime key early in boot process.

## Breaking Changes

### Default to Separated-Key Mode
`gen-new-host` now creates separated-key hosts by default. Use `--single-key` flag for legacy single-key mode.

**Backward compatibility:** Existing single-key hosts remain fully functional.

## Migration Tools for Existing Hosts

Three new tools help migrate existing single-key hosts to separated-key architecture:

- **`enable-key-separation`** - Generates runtime keys and updates `.sops.yaml` configuration
- **`install-runtime-key`** - Deploys runtime key to `/persist/etc/ssh/` on target host
- **`rotate-boot-key`** - Securely replaces boot key via partition wipe (optional but recommended)

Complete migration workflow is documented in `docs/normal-operations.md`.

## Testing

- ✅ Fresh separated-key hosts created with `gen-new-host`
- ✅ Single-key hosts migrating to separated-key mode
- ✅ Boot key rotation with `rotate-boot-key`
