### PR TITLE
pass pkgs directly to let downstream override lib

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -36,7 +36,12 @@
     nixos-facter-modules,
     nix-flake-tests,
     ...
-  }: flake-parts.lib.mkFlake { inherit inputs; } {
+  }: let
+    skaraboxLib = import ./lib/functions.nix { inherit (inputs) nixpkgs; };
+  in flake-parts.lib.mkFlake {
+    inherit inputs;
+    specialArgs = { inherit skaraboxLib; };
+  } {
     systems = [
       "x86_64-linux"
       "aarch64-linux"
@@ -50,7 +55,7 @@
         # Usage:
         #  init [-h] [-y] [-s] [-v] [-p PATH]
         #
-        # print help:
+        # printasdf help:
         #  init -h
         init = import ./lib/gen-initial.nix {
           inherit pkgs gen-new-host sops-create-main-key sops-add-main-key;
@@ -120,7 +125,7 @@
     };
 
     flake = {
-      lib = import ./lib/functions.nix;
+      lib = skaraboxLib;
 
       skaraboxInputs = inputs;
 

--- a/flakeModules/colmena.nix
+++ b/flakeModules/colmena.nix
@@ -22,7 +22,7 @@ in
       mkFlake = name: cfg': {
         colmenaHive = inputs.colmena.lib.makeHive ({
           meta.nixpkgs = import inputs.nixpkgs { system = "x86_64-linux"; };
-          meta.nodeNixpkgs = mapAttrs (_: cfg': import cfg'.nixpkgs { inherit (cfg') system; }) cfg.hosts;
+          meta.nodeNixpkgs = mapAttrs (_: cfg': import (if cfg'.nixpkgs != null then cfg'.nixpkgs else inputs.nixpkgs)  { inherit (cfg') system; }) cfg.hosts;
         } // (let
           mkNode = name: cfg': let
             hostCfg = topLevelConfig.flake.nixosConfigurations.${name}.config;

--- a/lib/functions.nix
+++ b/lib/functions.nix
@@ -1,14 +1,17 @@
+{ nixpkgs }:
 {
   # nixosSystem is found in nixpkgs/flake.nix and we must
   # copy it here to be able to use the full patched nixpkgs.
   # Otherwise, we can override pkgs which is a good first step
   # but we can't access the patched lib/ or nixos/modules/ this way.
   nixosSystem =
-    nixpkgs:
-    args:
-    import "${nixpkgs}/nixos/lib/eval-config.nix" (
+    args@{
+      lib ? null,
+      nixpkgs' ? nixpkgs,
+      ...
+    }:
+    import "${nixpkgs'}/nixos/lib/eval-config.nix" (
       {
-        lib = import "${nixpkgs}/lib";
         system = null;
         modules = args.modules ++ [
           ({ config, pkgs, lib, ... }:
@@ -18,6 +21,7 @@
           )
         ];
       }
-      // builtins.removeAttrs args [ "modules" ]
+      // (if lib == null then {} else { inherit lib; })
+      // builtins.removeAttrs args [ "modules" "lib" "nixpkgs'" ]
     );
 }

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -38,8 +38,9 @@
 
     skarabox.hosts = {
       myskarabox = {
-        # Comment this line to use nixpkgs as the input instead of SelfHostBlocks.
+        # Comment these two lines to use nixpkgs as the input instead of SelfHostBlocks.
         nixpkgs = inputs.selfhostblocks.lib.${config.skarabox.hosts.myskarabox.system}.patchedNixpkgs;
+        pkgs = inputs.selfhostblocks.lib.${config.skarabox.hosts.myskarabox.system}.pkgs;
         system = "x86_64-linux";
         hostKeyPub = ./myskarabox/host_key.pub;
         ip = "192.168.1.30";


### PR DESCRIPTION
This change is required to let downstream - in this case SelfHostBlocks - override lib and pass this new lib inside systems created with nixosSystem.