### PR TITLE
impermanence: add dataset to store zpool.cache

### DIFF
--- a/modules/disks.nix
+++ b/modules/disks.nix
@@ -244,6 +244,13 @@ in
               mountpoint = "/var/lib/nixos";
               options.mountpoint = "legacy";
             };
+
+            # https://nixos.org/manual/nixos/stable/#sec-zfs-state
+            "safe/zpool-cache" = {
+              type = "zfs_fs";
+              mountpoint = "/etc/zfs";
+              options.mountpoint = "legacy";
+            };
           };
         };
 


### PR DESCRIPTION
Follows https://nixos.org/manual/nixos/stable/#sec-zfs-state

The following steps **must be run before deploying the new configuration**.

```nix
[skarabox@myskarabox:~]$ sudo zfs create root/safe/zpool-cache

[skarabox@myskarabox:~]$ sudo zfs set mountpoint=/etc/zfs2 root/safe/zpool-cache

[skarabox@myskarabox:~]$ sudo rsync -av /etc/zfs/ /etc/zfs2
sending incremental file list
zfs/
zfs/zpool.cache
zfs/zpool.d -> /etc/static/zfs/zpool.d
zfs/zed.d/
zfs/zed.d/all-syslog.sh -> /etc/static/zfs/zed.d/all-syslog.sh
...
zfs/zed.d/zed.rc -> /etc/static/zfs/zed.d/zed.rc

sent 8,213 bytes  received 95 bytes  16,616.00 bytes/sec
total size is 7,455  speedup is 0.90

[skarabox@myskarabox:~]$ sudo zfs set mountpoint=legacy root/safe/zpool-cache
```

Now, you can deploy. I advise rebooting too to make sure everything is alright.