### PR TITLE
impermanence: save systemd state

### DIFF
--- a/modules/disks.nix
+++ b/modules/disks.nix
@@ -251,6 +251,13 @@ in
               mountpoint = "/etc/zfs";
               options.mountpoint = "legacy";
             };
+
+            # https://nixos.org/manual/nixos/stable/#sec-var-systemd
+            "safe/var-lib-systemd" = {
+              type = "zfs_fs";
+              mountpoint = "/var/lib/systemd";
+              options.mountpoint = "legacy";
+            };
           };
         };
 


### PR DESCRIPTION
Follows https://nixos.org/manual/nixos/stable/#sec-var-systemd

The following steps **must be run before deploying the new configuration**.

```nix
[skarabox@myskarabox:~]$ sudo zfs create root/safe/var-lib-systemd

[skarabox@myskarabox:~]$ sudo zfs set mountpoint=/var/lib/systemd2 root/safe/var-lib-systemd

[skarabox@myskarabox:~]$ sudo rsync -av /var/lib/systemd/ /var/lib/systemd2
sending incremental file list
systemd/
systemd/random-seed
systemd/catalog/
systemd/catalog/database
systemd/coredump/
systemd/ephemeral-trees/
systemd/linger/
systemd/network/
systemd/rfkill/
systemd/rfkill/pci-0000:01:00.0-usb-0:8:1.0:bluetooth
systemd/rfkill/pci-0000:03:00.0:wlan
systemd/timers/
systemd/timers/stamp-acme-renew-authelia.tiserbox.com.timer
...
systemd/timers/stamp-zpool-trim.timer
systemd/timesync/
systemd/timesync/clock

sent 291,825 bytes  received 820 bytes  585,290.00 bytes/sec
total size is 288,314  speedup is 0.99

[skarabox@myskarabox:~]$ sudo zfs set mountpoint=legacy root/safe/var-lib-systemd
```

Now, you can deploy. I advise rebooting too to make sure everything is alright.