### PR TITLE
impermanence: save journalctl state

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,7 +69,7 @@
         };
 
         gen-new-host = import ./lib/gen-new-host.nix {
-          inherit add-sops-cfg pkgs gen-hostId;
+          inherit add-sops-cfg pkgs gen-hostId gen-machineId;
           inherit (pkgs) lib;
         };
 
@@ -81,8 +81,20 @@
           ];
 
           text = ''
-          uuidgen | head -c 8
-        '';
+            uuidgen | head -c 8
+          '';
+        };
+
+        gen-machineId = pkgs.writeShellApplication {
+          name = "gen-machineId";
+
+          runtimeInputs = [
+            pkgs.util-linux
+          ];
+
+          text = ''
+            uuidgen -r | tr -d -
+          '';
         };
 
         manualHtml = pkgs.callPackage ./docs {

--- a/lib/gen-new-host.nix
+++ b/lib/gen-new-host.nix
@@ -3,6 +3,7 @@
   lib,
   add-sops-cfg,
   gen-hostId,
+  gen-machineId,
 }:
 pkgs.writeShellApplication {
   name = "gen-new-host";
@@ -124,6 +125,9 @@ USAGE
 
     e "Generating hostid..."
     sed -i "s/\(skarabox.hostId =\) null;/\1 \"$(${lib.getExe gen-hostId})\";/" "$configuration"
+
+    e "Generating machineid..."
+    sed -i "s/\(skarabox.machineId =\) null;/\1 \"$(${lib.getExe gen-machineId})\";/" "$configuration"
 
     sops_cfg="./.sops.yaml"
     secrets="$hostname/secrets.yaml"

--- a/modules/configuration.nix
+++ b/modules/configuration.nix
@@ -14,6 +14,8 @@ in
     networking.hostName = cfg.hostname;
     networking.hostId = cfg.hostId;
 
+    environment.etc."machine-id".text = cfg.machineId;
+
     powerManagement.cpuFreqGovernor = "performance";
 
     nix.settings.trusted-users = [ cfg.username ];

--- a/modules/disks.nix
+++ b/modules/disks.nix
@@ -258,6 +258,13 @@ in
               mountpoint = "/var/lib/systemd";
               options.mountpoint = "legacy";
             };
+
+            # https://nixos.org/manual/nixos/stable/#sec-var-journal
+            "safe/var-log-journal" = {
+              type = "zfs_fs";
+              mountpoint = "/var/log/journal";
+              options.mountpoint = "legacy";
+            };
           };
         };
 

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -39,6 +39,15 @@ in
       '';
     };
 
+    machineId = mkOption {
+      type = types.str;
+      description = ''
+        Unique identifier. Generate with `uuidgen -r | tr -d -`.
+
+        This must be persisted https://nixos.org/manual/nixos/stable/#sec-machine-id
+      '';
+    };
+
     sshPort = mkOption {
       type = types.int;
       default = 2222;

--- a/template/myskarabox/configuration.nix
+++ b/template/myskarabox/configuration.nix
@@ -37,6 +37,7 @@ in
       skarabox.sshPort = 2222;
       skarabox.sshAuthorizedKey = ./ssh.pub;
       skarabox.hostId = null;
+      skarabox.machineId = null;
 
       # Hardware drivers are figured out using nixos-facter.
       # If it still fails to find the correct driver,


### PR DESCRIPTION
Follows https://nixos.org/manual/nixos/stable/#sec-var-journal and https://nixos.org/manual/nixos/stable/#sec-machine-id

The following steps **must be run before deploying the new configuration**.

```nix
[skarabox@myskarabox:~]$ sudo zfs create root/safe/var-log-journal

[skarabox@myskarabox:~]$ sudo zfs set mountpoint=/var/log/journal2 root/safe/var-log-journal

[skarabox@myskarabox:~]$ sudo rsync -av /var/log/journal /var/log/journal2

[skarabox@myskarabox:~]$ sudo zfs set mountpoint=legacy root/safe/var-log-journal
```

Now, you can deploy. I advise rebooting too to make sure everything is alright.