### PR TITLE
Template: fix templating of secrets.yaml

### DIFF
--- a/template/secrets.yaml
+++ b/template/secrets.yaml
@@ -1,8 +1,0 @@
-# I'm empty and in plain text right now
-# but I will contain soon be encrypted with all the secrets!
-skarabox:
-  user:
-    hashedPassword: <nix run .#mkpasswd>
-  disks:
-    rootPassphrase: <nix run .#openssl -- rand -hex 64>
-    dataPassphrase: <nix run .#openssl -- rand -hex 64>

--- a/tests/variants.nix
+++ b/tests/variants.nix
@@ -84,6 +84,12 @@ let
     sed -i "s/\(skarabox.boot.sshPort =\) 2223/\1 $sshBootPort/" "./myskarabox/configuration.nix"
     sed -i "s/\(sshBootPort =\) 2223/\1 $sshBootPort/" "./flake.nix"
     ${nix} run .#myskarabox-gen-knownhosts-file --show-trace
+
+    if grep -R "I'm empty and in plain text right now" .; then
+      echo "Failed to replace secrets file, fix the templating."
+      exit 1
+    fi
+
     # Using a git repo here allows to only copy in the nix store non temporary files.
     # In particular, we avoid copying the disk*.qcow2 files.
     git init


### PR DESCRIPTION
The initial `secrets.yaml` file was left in its templated form.