### PR TITLE
Add separate beacon trust flow

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -113,6 +113,15 @@ skarabox.hosts.<name> = {
 
 Then, start the VM using the following command which will create a graphical window:
 
+Generate the known hosts file:
+
+```bash
+nix run .#myskarabox-gen-knownhosts-file
+```
+
+This file is for the final installed system. The beacon VM has its own temporary
+SSH host key, which will be trusted after the VM starts.
+
 ```bash
 $ nix run .#myskarabox-beacon-vm &
 ```
@@ -123,6 +132,12 @@ will not be able to run in the background, like above.
 
 ```bash
 $ nix run .#myskarabox-beacon-vm -- -nographic
+```
+
+Trust the beacon SSH host key:
+
+```bash
+$ nix run .#myskarabox-beacon-trust
 ```
 
 For info, this VM has 4 hard drives:
@@ -236,7 +251,25 @@ Connecting to the beacon will thus depend on the chosen method.
    It is also possible to use a hostname as long as it can resolve to the correct IP,
    for example if you set up your ssh config accordingly.
 
-8. Open the various files just to see if everything looks good.
+8. Generate the known host file for the final installed system:
+
+   ```bash
+   $ nix run .#myskarabox-gen-knownhosts-file
+   ```
+
+   Redo this step if any of the ssh port or IP under the flake `skarabox.hosts.<name>` option changes.
+
+9. Trust the beacon SSH host key:
+
+   ```bash
+   $ nix run .#myskarabox-beacon-trust
+   ```
+
+   This writes `./myskarabox/beacon_known_hosts`, which is local trust state for
+   the temporary beacon environment. If the beacon is rebooted and its key
+   changes, rerun the command with `--force` after verifying the new fingerprint.
+
+10. Open the various files just to see if everything looks good.
 
 ### B. (option 3) Install on a Cloud Server {#b-beacon-cloud}
 
@@ -265,6 +298,21 @@ skarabox.hosts.<name>.beacon = {
 }
 ```
 
+This file is for the final installed system. To trust the cloud rescue
+environment used for installation, run:
+
+```bash
+nix run .#myskarabox-beacon-trust
+```
+
+[nixos-anywhere]: https://github.com/nix-community/nixos-anywhere
+
+Test the ssh connection with:
+
+```bash
+$ nix run .#myskarabox-beacon-ssh -- -v
+```
+
 ## C. Run the Installer {#c-installer}
 
 1. (Optional) Get into NixOS installer
@@ -282,31 +330,20 @@ $ nix run .#myskarabox-install-on-beacon -- --phases kexec
 Test the ssh connection with:
 
 ```bash
-$ nix run .#myskarabox-ssh-beacon
+$ nix run .#myskarabox-beacon-ssh
 ```
 
 Set verbose mode if something goes wrong with:
 
 ```bash
-$ nix run .#myskarabox-ssh-beacon -- -v
+$ nix run .#myskarabox-beacon-ssh -- -v
 ```
-
-Upon rebooting the beacon,
-a new host key is generating leading to the message
-saying there might be a man in the middle attack.
-This warning can be dismissed when connecting to the beacon.
-
-::: {.warning}
-This is not the case for the target host after installation.
-The ssh host key will not change after a reboot.
-Getting the warning a that time must be investigated and not blindly dismissed.
-:::
 
 3. Print the disk layout
 
 ```bash
-$ nix run .#myskarabox-ssh-beacon -- sudo fdisk -l
-$ nix run .#myskarabox-ssh-beacon -- lsblk
+$ nix run .#myskarabox-beacon-ssh -- sudo fdisk -l
+$ nix run .#myskarabox-beacon-ssh -- lsblk
 ```
 
 Set the options `skarabox.disks` in `./myskarabox/configuration.nix` accordingly.
@@ -317,7 +354,7 @@ Generate a `./myskarabox/facter.json` file containing
 the hardware specification of the host (or the VM) with:
 
 ```bash
-$ nix run .#myskarabox-get-facter > ./myskarabox/facter.json
+$ nix run .#myskarabox-beacon-get-facter > ./myskarabox/facter.json
 ```
 
 ::: {.warning}
@@ -349,7 +386,7 @@ so it is expected for the steps in this section to not care about it.
 Now, run the installation process on the target host:
 
 ```bash
-$ nix run .#myskarabox-install-on-beacon
+$ nix run .#myskarabox-beacon-install
 ```
 
 :::{.info}

--- a/flakeModules/beacon-trust.py
+++ b/flakeModules/beacon-trust.py
@@ -1,0 +1,135 @@
+import argparse
+import pathlib
+import subprocess
+import sys
+import tempfile
+
+
+class BeaconTrustError(Exception):
+    pass
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Trust the scanned beacon SSH host key.",
+    )
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="trust the scanned beacon host key without prompting",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="replace an existing beacon known_hosts file if it differs",
+    )
+    for name in ("--beacon-ip", "--beacon-port", "--beacon-host-alias"):
+        parser.add_argument(name, required=True, help=argparse.SUPPRESS)
+    parser.add_argument(
+        "--beacon-known-hosts",
+        required=True,
+        type=pathlib.Path,
+        help=argparse.SUPPRESS,
+    )
+    return parser.parse_args()
+
+
+def trust_beacon(args: argparse.Namespace) -> None:
+    destination = args.beacon_known_hosts
+    target = f"{args.beacon_ip}:{args.beacon_port}"
+
+    keyscan = subprocess.run(
+        [
+            "ssh-keyscan",
+            "-T",
+            "10",
+            "-p",
+            args.beacon_port,
+            args.beacon_ip,
+        ],
+        text=True,
+        capture_output=True,
+    )
+    if keyscan.returncode != 0:
+        raise BeaconTrustError(
+            f"Failed to scan beacon SSH host key at {target}"
+        )
+
+    lines: list[str] = []
+    for line in keyscan.stdout.splitlines():
+        if not line or line.startswith("#"):
+            continue
+
+        fields = line.split()
+        if len(fields) != 3:
+            raise BeaconTrustError(
+                f"Unexpected ssh-keyscan output line: {line}"
+            )
+
+        lines.append(f"{args.beacon_host_alias} {fields[1]} {fields[2]}")
+    if not lines:
+        raise BeaconTrustError(f"No beacon SSH host key found at {target}")
+
+    content = ("\n".join(lines) + "\n").encode()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.TemporaryDirectory(
+        dir=destination.parent,
+        prefix=f"{destination.name}.tmp.",
+    ) as tmp_dir:
+        tmp_path = pathlib.Path(tmp_dir) / destination.name
+        tmp_path.write_bytes(content)
+        fingerprints = subprocess.run(
+            ["ssh-keygen", "-l", "-f", str(tmp_path)],
+            text=True,
+            capture_output=True,
+        )
+        if fingerprints.returncode != 0:
+            sys.stderr.write(fingerprints.stderr)
+            raise BeaconTrustError(
+                "Failed to print beacon SSH host key fingerprints"
+            )
+
+        print("Scanned beacon SSH host key fingerprints:", file=sys.stderr)
+        sys.stderr.write(fingerprints.stdout)
+
+        if (
+            destination.exists()
+            and destination.read_bytes() != content
+            and not args.force
+        ):
+            raise BeaconTrustError(
+                f"Beacon host key differs from {destination}.\n"
+                "Verify the new fingerprint, then rerun with "
+                "--force to replace it."
+            )
+
+        if not args.yes:
+            print(
+                "Trust this beacon host key? [y/N]: ",
+                end="",
+                file=sys.stderr,
+                flush=True,
+            )
+            answer = sys.stdin.readline().strip().lower()
+            if answer not in {"y", "yes"}:
+                raise BeaconTrustError("Aborting.")
+
+        tmp_path.replace(destination)
+        print(
+            f"Wrote {destination} for {args.beacon_host_alias}.",
+            file=sys.stderr,
+        )
+
+
+def main() -> int:
+    try:
+        trust_beacon(parse_args())
+    except BeaconTrustError as err:
+        print(err, file=sys.stderr)
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/flakeModules/default.nix
+++ b/flakeModules/default.nix
@@ -200,6 +200,11 @@ in
                   type = types.str;
                   default = "${name}/known_hosts";
                 };
+                beaconKnownHostsPath = mkOption {
+                  description = "Path from the top of the repo to the known hosts file used only for beacon SSH access.";
+                  type = types.str;
+                  default = "${name}/beacon_known_hosts";
+                };
                 system = mkOption {
                   description = ''
                     System of the host.
@@ -506,6 +511,68 @@ in
               '';
             };
 
+            beacon-trust =
+              let
+                script = pkgs.writers.writePython3Bin "beacon-trust" { } (builtins.readFile ./beacon-trust.py);
+                flags = {
+                  beacon-ip = toString cfg'.ip;
+                  beacon-port = toString cfg'.beacon.sshPort;
+                  beacon-host-alias = "${name}-beacon";
+                  beacon-known-hosts = cfg'.beaconKnownHostsPath;
+                };
+                flagArgs = lib.flatten (
+                  lib.mapAttrsToList (flag: value: [
+                    "--${flag}"
+                    value
+                  ]) flags
+                );
+                wrapperFlags = lib.escapeShellArg (lib.escapeShellArgs flagArgs);
+              in
+              pkgs.symlinkJoin {
+                name = "beacon-trust";
+                paths = [
+                  script
+                ];
+                nativeBuildInputs = [
+                  pkgs.makeWrapper
+                ];
+                postBuild = ''
+                  wrapProgram "$out/bin/beacon-trust" \
+                    --prefix PATH : ${lib.makeBinPath [ pkgs.openssh ]} \
+                    --add-flags ${wrapperFlags}
+                '';
+              };
+
+            beacon-ssh = pkgs.writeShellApplication {
+              name = "beacon-ssh";
+
+              runtimeInputs = [
+                pkgs.openssh
+              ];
+
+              text = ''
+                known_hosts="${cfg'.beaconKnownHostsPath}"
+
+                if [ ! -s "$known_hosts" ]; then
+                  echo "Missing beacon known_hosts file: $known_hosts" >&2
+                  echo "Run: nix run .#${name}-beacon-trust" >&2
+                  exit 1
+                fi
+
+                ssh \
+                  -p "${toString cfg'.beacon.sshPort}" \
+                  -o IdentitiesOnly=yes \
+                  -o UserKnownHostsFile="$known_hosts" \
+                  -o HostKeyAlias="${name}-beacon" \
+                  -o StrictHostKeyChecking=yes \
+                  -o ConnectTimeout=10 \
+                  ${if cfg'.beacon.sshPrivateKeyPath != null then "-i ${cfg'.beacon.sshPrivateKeyPath}" else ""} \
+                  ${if cfg'.beacon.sshPublicKeyPath != null then "-i ${cfg'.beacon.sshPublicKeyPath}" else ""} \
+                  "${cfg'.beacon.username}@${cfg'.ip}" \
+                  "$@"
+              '';
+            };
+
             # Install a nixosConfigurations instance (<flake>) on a server.
             #
             # This command is intended to be run against a server which
@@ -513,11 +580,11 @@ in
             # on any OS supported by nixos-anywhere. The latter has not been
             # tested in the context of Skarabox.
             #
-            #   nix run .#install-on-beacon [<command> ...]
-            #   nix run .#install-on-beacon
-            #   nix run .#install-on-beacon -v
-            install-on-beacon = pkgs.writeShellApplication {
-              name = "install-on-beacon";
+            #   nix run .#beacon-install [<command> ...]
+            #   nix run .#beacon-install
+            #   nix run .#beacon-install -v
+            beacon-install = pkgs.writeShellApplication {
+              name = "beacon-install";
               runtimeInputs = [
                 (import ../lib/install-on-beacon.nix {
                   inherit pkgs;
@@ -549,11 +616,18 @@ in
                     mapAttrsToList mkTmpFile secrets;
                 in
                 ''
-                  ip=${toString cfg'.ip}
-                  ssh_port=${toString cfg'.beacon.sshPort}
+                  ip="${toString cfg'.ip}"
+                  ssh_port="${toString cfg'.beacon.sshPort}"
                   flake=".#${toString name}"
+                  beacon_known_hosts="${cfg'.beaconKnownHostsPath}"
 
                   export SOPS_AGE_KEY_FILE="${cfg.sopsKeyPath}"
+
+                  if [ ! -s "$beacon_known_hosts" ]; then
+                    echo "Missing beacon known_hosts file: $beacon_known_hosts" >&2
+                    echo "Run: nix run .#${name}-beacon-trust" >&2
+                    exit 1
+                  fi
 
                 ''
                 + concatStringsSep "\n" diskEncryptionTmpFiles
@@ -565,6 +639,18 @@ in
                       ++ [
                         "--ssh-option"
                         "ConnectTimeout=10"
+                      ]
+                      ++ [
+                        "--ssh-option"
+                        "UserKnownHostsFile=${cfg'.beaconKnownHostsPath}"
+                      ]
+                      ++ [
+                        "--ssh-option"
+                        "HostKeyAlias=${name}-beacon"
+                      ]
+                      ++ [
+                        "--ssh-option"
+                        "StrictHostKeyChecking=yes"
                       ]
                       ++ (lib.optionals (cfg'.beacon.sshPrivateKeyPath != null) [
                         "-i"
@@ -604,6 +690,19 @@ in
                 );
             };
 
+            install-on-beacon = pkgs.writeShellApplication {
+              name = "install-on-beacon";
+
+              runtimeInputs = [
+                beacon-install
+              ];
+
+              text = ''
+                echo "warning: ${name}-install-on-beacon is deprecated; use ${name}-beacon-install" >&2
+                beacon-install "$@"
+              '';
+            };
+
             # nix run .#ssh [<command> ...]
             # nix run .#ssh
             # nix run .#ssh echo hello
@@ -632,30 +731,41 @@ in
             };
 
             ssh-beacon = pkgs.writeShellApplication {
-              name = "ssh";
+              name = "ssh-beacon";
 
               runtimeInputs = [
-                (import ../lib/ssh.nix {
-                  inherit pkgs;
-                })
+                beacon-ssh
               ];
 
               text = ''
-                ssh \
-                  "${cfg'.ip}" \
-                  "${toString cfg'.beacon.sshPort}" \
-                  ${cfg'.beacon.username} \
-                  -o ConnectTimeout=10 \
-                  -o StrictHostKeyChecking=accept-new \
-                  -o UserKnownHostsFile=/dev/null \
-                  ${if cfg'.beacon.sshPrivateKeyPath != null then "-i ${cfg'.beacon.sshPrivateKeyPath}" else ""} \
-                  ${if cfg'.beacon.sshPublicKeyPath != null then "-i ${cfg'.beacon.sshPublicKeyPath}" else ""} \
-                  "$@"
+                echo "warning: ${name}-ssh-beacon is deprecated; use ${name}-beacon-ssh" >&2
+                beacon-ssh "$@"
               '';
             };
 
-            get-facter = import ../lib/get-facter.nix {
-              inherit name pkgs ssh-beacon;
+            beacon-get-facter = pkgs.writeShellApplication {
+              name = "beacon-get-facter";
+
+              runtimeInputs = [
+                beacon-ssh
+              ];
+
+              text = ''
+                beacon-ssh sudo nixos-facter
+              '';
+            };
+
+            get-facter = pkgs.writeShellApplication {
+              name = "get-facter";
+
+              runtimeInputs = [
+                beacon-get-facter
+              ];
+
+              text = ''
+                echo "warning: ${name}-get-facter is deprecated; use ${name}-beacon-get-facter" >&2
+                beacon-get-facter "$@"
+              '';
             };
 
             unlock = pkgs.writeShellApplication {
@@ -693,6 +803,10 @@ in
             "${name}-boot-ssh" = boot-ssh;
             "${name}-sops" = sops;
             "${name}-beacon" = beacon;
+            "${name}-beacon-trust" = beacon-trust;
+            "${name}-beacon-ssh" = beacon-ssh;
+            "${name}-beacon-get-facter" = beacon-get-facter;
+            "${name}-beacon-install" = beacon-install;
             "${name}-beacon-vm" = beacon-vm;
             "${name}-ssh-beacon" = ssh-beacon;
             "${name}-gen-knownhosts-file" = gen-knownhosts-file;

--- a/flakeModules/default.nix
+++ b/flakeModules/default.nix
@@ -200,6 +200,11 @@ in
                   type = types.str;
                   default = "${name}/known_hosts";
                 };
+                beaconKnownHostsPath = mkOption {
+                  description = "Path from the top of the repo to the known hosts file used only for beacon SSH access.";
+                  type = types.str;
+                  default = "${name}/beacon_known_hosts";
+                };
                 system = mkOption {
                   description = ''
                     System of the host.
@@ -506,6 +511,68 @@ in
               '';
             };
 
+            beacon-trust =
+              let
+                script = pkgs.writers.writePython3Bin "beacon-trust" { } (builtins.readFile ./beacon-trust.py);
+                flags = {
+                  beacon-ip = toString cfg'.ip;
+                  beacon-port = toString cfg'.beacon.sshPort;
+                  beacon-host-alias = "${name}-beacon";
+                  beacon-known-hosts = cfg'.beaconKnownHostsPath;
+                };
+                flagArgs = lib.flatten (
+                  lib.mapAttrsToList (flag: value: [
+                    "--${flag}"
+                    value
+                  ]) flags
+                );
+                wrapperFlags = lib.escapeShellArg (lib.escapeShellArgs flagArgs);
+              in
+              pkgs.symlinkJoin {
+                name = "beacon-trust";
+                paths = [
+                  script
+                ];
+                nativeBuildInputs = [
+                  pkgs.makeWrapper
+                ];
+                postBuild = ''
+                  wrapProgram "$out/bin/beacon-trust" \
+                    --prefix PATH : ${lib.makeBinPath [ pkgs.openssh ]} \
+                    --add-flags ${wrapperFlags}
+                '';
+              };
+
+            beacon-ssh = pkgs.writeShellApplication {
+              name = "beacon-ssh";
+
+              runtimeInputs = [
+                pkgs.openssh
+              ];
+
+              text = ''
+                known_hosts="${cfg'.beaconKnownHostsPath}"
+
+                if [ ! -s "$known_hosts" ]; then
+                  echo "Missing beacon known_hosts file: $known_hosts" >&2
+                  echo "Run: nix run .#${name}-beacon-trust" >&2
+                  exit 1
+                fi
+
+                ssh \
+                  -p "${toString cfg'.beacon.sshPort}" \
+                  -o IdentitiesOnly=yes \
+                  -o UserKnownHostsFile="$known_hosts" \
+                  -o HostKeyAlias="${name}-beacon" \
+                  -o StrictHostKeyChecking=yes \
+                  -o ConnectTimeout=10 \
+                  ${if cfg'.beacon.sshPrivateKeyPath != null then "-i ${cfg'.beacon.sshPrivateKeyPath}" else ""} \
+                  ${if cfg'.beacon.sshPublicKeyPath != null then "-i ${cfg'.beacon.sshPublicKeyPath}" else ""} \
+                  "${cfg'.beacon.username}@${cfg'.ip}" \
+                  "$@"
+              '';
+            };
+
             # Install a nixosConfigurations instance (<flake>) on a server.
             #
             # This command is intended to be run against a server which
@@ -513,11 +580,11 @@ in
             # on any OS supported by nixos-anywhere. The latter has not been
             # tested in the context of Skarabox.
             #
-            #   nix run .#install-on-beacon [<command> ...]
-            #   nix run .#install-on-beacon
-            #   nix run .#install-on-beacon -v
-            install-on-beacon = pkgs.writeShellApplication {
-              name = "install-on-beacon";
+            #   nix run .#beacon-install [<command> ...]
+            #   nix run .#beacon-install
+            #   nix run .#beacon-install -v
+            beacon-install = pkgs.writeShellApplication {
+              name = "beacon-install";
               runtimeInputs = [
                 (import ../lib/install-on-beacon.nix {
                   inherit pkgs;
@@ -549,11 +616,18 @@ in
                     mapAttrsToList mkTmpFile secrets;
                 in
                 ''
-                  ip=${toString cfg'.ip}
-                  ssh_port=${toString cfg'.beacon.sshPort}
+                  ip="${toString cfg'.ip}"
+                  ssh_port="${toString cfg'.beacon.sshPort}"
                   flake=".#${toString name}"
+                  beacon_known_hosts="${cfg'.beaconKnownHostsPath}"
 
                   export SOPS_AGE_KEY_FILE="${cfg.sopsKeyPath}"
+
+                  if [ ! -s "$beacon_known_hosts" ]; then
+                    echo "Missing beacon known_hosts file: $beacon_known_hosts" >&2
+                    echo "Run: nix run .#${name}-beacon-trust" >&2
+                    exit 1
+                  fi
 
                 ''
                 + concatStringsSep "\n" diskEncryptionTmpFiles
@@ -565,6 +639,18 @@ in
                       ++ [
                         "--ssh-option"
                         "ConnectTimeout=10"
+                      ]
+                      ++ [
+                        "--ssh-option"
+                        "UserKnownHostsFile=${cfg'.beaconKnownHostsPath}"
+                      ]
+                      ++ [
+                        "--ssh-option"
+                        "HostKeyAlias=${name}-beacon"
+                      ]
+                      ++ [
+                        "--ssh-option"
+                        "StrictHostKeyChecking=yes"
                       ]
                       ++ (lib.optionals (cfg'.beacon.sshPrivateKeyPath != null) [
                         "-i"
@@ -604,6 +690,19 @@ in
                 );
             };
 
+            install-on-beacon = pkgs.writeShellApplication {
+              name = "install-on-beacon";
+
+              runtimeInputs = [
+                beacon-install
+              ];
+
+              text = ''
+                echo "warning: ${name}-install-on-beacon is deprecated; use ${name}-beacon-install" >&2
+                beacon-install "$@"
+              '';
+            };
+
             # nix run .#ssh [<command> ...]
             # nix run .#ssh
             # nix run .#ssh echo hello
@@ -632,30 +731,41 @@ in
             };
 
             ssh-beacon = pkgs.writeShellApplication {
-              name = "ssh";
+              name = "ssh-beacon";
 
               runtimeInputs = [
-                (import ../lib/ssh.nix {
-                  inherit pkgs;
-                })
+                beacon-ssh
               ];
 
               text = ''
-                ssh \
-                  "${cfg'.ip}" \
-                  "${toString cfg'.beacon.sshPort}" \
-                  ${cfg'.beacon.username} \
-                  -o ConnectTimeout=10 \
-                  -o StrictHostKeyChecking=accept-new \
-                  -o UserKnownHostsFile=/dev/null \
-                  ${if cfg'.beacon.sshPrivateKeyPath != null then "-i ${cfg'.beacon.sshPrivateKeyPath}" else ""} \
-                  ${if cfg'.beacon.sshPublicKeyPath != null then "-i ${cfg'.beacon.sshPublicKeyPath}" else ""} \
-                  "$@"
+                echo "warning: ${name}-ssh-beacon is deprecated; use ${name}-beacon-ssh" >&2
+                beacon-ssh "$@"
               '';
             };
 
-            get-facter = import ../lib/get-facter.nix {
-              inherit name pkgs ssh-beacon;
+            beacon-get-facter = pkgs.writeShellApplication {
+              name = "beacon-get-facter";
+
+              runtimeInputs = [
+                beacon-ssh
+              ];
+
+              text = ''
+                beacon-ssh sudo nixos-facter
+              '';
+            };
+
+            get-facter = pkgs.writeShellApplication {
+              name = "get-facter";
+
+              runtimeInputs = [
+                beacon-get-facter
+              ];
+
+              text = ''
+                echo "warning: ${name}-get-facter is deprecated; use ${name}-beacon-get-facter" >&2
+                beacon-get-facter "$@"
+              '';
             };
 
             unlock = pkgs.writeShellApplication {
@@ -678,6 +788,10 @@ in
             "${name}-boot-ssh" = boot-ssh;
             "${name}-sops" = sops;
             "${name}-beacon" = beacon;
+            "${name}-beacon-trust" = beacon-trust;
+            "${name}-beacon-ssh" = beacon-ssh;
+            "${name}-beacon-get-facter" = beacon-get-facter;
+            "${name}-beacon-install" = beacon-install;
             "${name}-beacon-vm" = beacon-vm;
             "${name}-ssh-beacon" = ssh-beacon;
             "${name}-gen-knownhosts-file" = gen-knownhosts-file;

--- a/template/.gitignore
+++ b/template/.gitignore
@@ -1,4 +1,5 @@
 .skarabox-tmp
+*/beacon_known_hosts
 ssh
 host_key
 sops.key

--- a/tests/static.nix
+++ b/tests/static.nix
@@ -116,24 +116,72 @@
 
     sleep 10
 
-    group "Starting ssh loop to figure out when beacon started."
+    group "Starting beacon trust loop to figure out when beacon started."
     e "You might see some flickering on the command line."
-    # We can't yet be strict on the host key check since the beacon
-    # initially has a random one.
-    while ! ${nix} run .#myskarabox-ssh -- -F none -o CheckHostIP=no -o StrictHostKeyChecking=no echo "connected"; do
+    deadline=$((SECONDS + 300))
+    while ! ${nix} run .#myskarabox-beacon-trust -- --yes; do
+      if [ "$SECONDS" -ge "$deadline" ]; then
+        echo "Timed out waiting for beacon trust to succeed"
+        exit 1
+      fi
       sleep 5
     done
     endgroup "Beacon VM has started."
 
+    group "Checking final host key is not trusted for beacon."
+    final_host_pub="$(cut -d' ' -f-2 ./myskarabox/host_key.pub)"
+    printf 'myskarabox-beacon %s\n' "$final_host_pub" > ./myskarabox/beacon_known_hosts
+    deadline=$((SECONDS + 120))
+    while true; do
+      if beacon_ssh_error="$(${nix} run .#myskarabox-beacon-ssh -- -F none echo "connected" 2>&1)"; then
+        echo "Beacon SSH unexpectedly accepted the final host key"
+        exit 1
+      fi
+      case "$beacon_ssh_error" in
+        *"Host key verification failed"*) break ;;
+      esac
+      if [ "$SECONDS" -ge "$deadline" ]; then
+        printf '%s\n' "$beacon_ssh_error" >&2
+        echo "Timed out waiting for beacon SSH to reject the final host key"
+        exit 1
+      fi
+      sleep 5
+    done
+    printf '%s\n' "$beacon_ssh_error" >&2
+    deadline=$((SECONDS + 120))
+    until ${nix} run .#myskarabox-beacon-trust -- --yes --force; do
+      if [ "$SECONDS" -ge "$deadline" ]; then
+        echo "Timed out restoring beacon trust"
+        exit 1
+      fi
+      sleep 5
+    done
+    deadline=$((SECONDS + 120))
+    until ${nix} run .#myskarabox-beacon-ssh -- -F none echo "connected"; do
+      if [ "$SECONDS" -ge "$deadline" ]; then
+        echo "Timed out waiting for beacon SSH to accept commands"
+        exit 1
+      fi
+      sleep 5
+    done
+    endgroup "Beacon trust is separate from final host trust."
+
     group "Generating hardware config."
-    ${nix} run .#myskarabox-get-facter > ./myskarabox/facter.json
+    deadline=$((SECONDS + 120))
+    until ${nix} run .#myskarabox-beacon-get-facter > ./myskarabox/facter.json; do
+      if [ "$SECONDS" -ge "$deadline" ]; then
+        echo "Timed out waiting for beacon facter collection to succeed"
+        exit 1
+      fi
+      sleep 5
+    done
     ${jq}/bin/jq < ./myskarabox/facter.json
     git add ./myskarabox/facter.json
     git commit -m 'generate hardware config'
     endgroup "Generation succeeded."
 
     group "Starting installation on beacon VM."
-    ${nix} run .#myskarabox-install-on-beacon -- --no-substitute-on-destination
+    ${nix} run .#myskarabox-beacon-install -- --no-substitute-on-destination
     endgroup "Installation succeeded."
 
     group "Starting unlock loop to decrypt root dataset."

--- a/tests/variants.nix
+++ b/tests/variants.nix
@@ -152,24 +152,72 @@ let
 
       sleep 10
 
-      group "Starting ssh loop to figure out when beacon started."
+      group "Starting beacon trust loop to figure out when beacon started."
       e "You might see some flickering on the command line."
-      # We can't yet be strict on the host key check since the beacon
-      # initially has a random one.
-      while ! ${nix} run .#myskarabox-ssh -- -F none -o CheckHostIP=no -o StrictHostKeyChecking=no echo "connected"; do
+      deadline=$((SECONDS + 300))
+      while ! ${nix} run .#myskarabox-beacon-trust -- --yes; do
+        if [ "$SECONDS" -ge "$deadline" ]; then
+          echo "Timed out waiting for beacon trust to succeed"
+          exit 1
+        fi
         sleep 5
       done
       endgroup "Beacon VM has started."
 
+      group "Checking final host key is not trusted for beacon."
+      final_host_pub="$(cut -d' ' -f-2 ./myskarabox/host_key.pub)"
+      printf 'myskarabox-beacon %s\n' "$final_host_pub" > ./myskarabox/beacon_known_hosts
+      deadline=$((SECONDS + 120))
+      while true; do
+        if beacon_ssh_error="$(${nix} run .#myskarabox-beacon-ssh -- -F none echo "connected" 2>&1)"; then
+          echo "Beacon SSH unexpectedly accepted the final host key"
+          exit 1
+        fi
+        case "$beacon_ssh_error" in
+          *"Host key verification failed"*) break ;;
+        esac
+        if [ "$SECONDS" -ge "$deadline" ]; then
+          printf '%s\n' "$beacon_ssh_error" >&2
+          echo "Timed out waiting for beacon SSH to reject the final host key"
+          exit 1
+        fi
+        sleep 5
+      done
+      printf '%s\n' "$beacon_ssh_error" >&2
+      deadline=$((SECONDS + 120))
+      until ${nix} run .#myskarabox-beacon-trust -- --yes --force; do
+        if [ "$SECONDS" -ge "$deadline" ]; then
+          echo "Timed out restoring beacon trust"
+          exit 1
+        fi
+        sleep 5
+      done
+      deadline=$((SECONDS + 120))
+      until ${nix} run .#myskarabox-beacon-ssh -- -F none echo "connected"; do
+        if [ "$SECONDS" -ge "$deadline" ]; then
+          echo "Timed out waiting for beacon SSH to accept commands"
+          exit 1
+        fi
+        sleep 5
+      done
+      endgroup "Beacon trust is separate from final host trust."
+
       group "Generating hardware config."
-      ${nix} run .#myskarabox-get-facter > ./myskarabox/facter.json
+      deadline=$((SECONDS + 120))
+      until ${nix} run .#myskarabox-beacon-get-facter > ./myskarabox/facter.json; do
+        if [ "$SECONDS" -ge "$deadline" ]; then
+          echo "Timed out waiting for beacon facter collection to succeed"
+          exit 1
+        fi
+        sleep 5
+      done
       ${jq}/bin/jq < ./myskarabox/facter.json
       git add ./myskarabox/facter.json
       git commit -m 'generate hardware config'
       endgroup "Generation succeeded."
 
       group "Starting installation on beacon VM."
-      ${nix} run .#myskarabox-install-on-beacon -- --no-substitute-on-destination
+      ${nix} run .#myskarabox-beacon-install -- --no-substitute-on-destination
       endgroup "Installation succeeded."
 
       group "Starting unlock loop to decrypt root dataset."


### PR DESCRIPTION
## Motivation
The on-premise install flow previously used the final host trust path while talking to the beacon. The beacon boots with its own generated SSH host key, so treating it like the final host makes the trust boundary ambiguous and can train users or tests to accept the wrong key during installation.

## Design
Introduce a dedicated beacon trust file, `<host>/beacon_known_hosts`, and make all beacon-specific commands use the `<host>-beacon` alias against that file. The normal final-host `known_hosts` file remains separate. The new trust command scans the beacon key, shows fingerprints, writes the beacon trust file only after confirmation or `--yes`, and requires `--force` when replacing a different trusted beacon key.

## Implemented changes
Add `<host>-beacon-trust`, `<host>-beacon-ssh`, `<host>-beacon-get-facter`, and `<host>-beacon-install`. Keep the old `<host>-get-facter` and `<host>-install-on-beacon` names as deprecated aliases with stderr warnings. Document the new flow, ignore generated `beacon_known_hosts` files in the template, and update VM tests to use the new beacon commands, verify that the final host key is rejected for beacon SSH, and use a bounded beacon-trust startup loop.

---

Fixes https://github.com/ibizaman/skarabox/issues/267.