### PR TITLE
Disable services.openssh.generateHostKeys in configuration

### DIFF
--- a/modules/configuration.nix
+++ b/modules/configuration.nix
@@ -72,6 +72,7 @@ in
       ports = [ cfg.sshPort ];
       openFirewall = true;
       hostKeys = lib.mkForce [];
+      generateHostKeys = false;
       extraConfig = ''
         HostKey /boot/host_key
       '';


### PR DESCRIPTION
Skarabox already manually provisions `/boot/host_key`; having `generateHostKeys` set to `true` creates an invalid `sshd-keygen` unit that spams logs with errors:

```
sshd-keygen.service: Service has no ExecStart=, ExecStop=, or SuccessAction=. Refusing.
sshd-keygen.service: Cannot add dependency job, ignoring: Unit sshd-keygen.service has a bad unit file setting.
```