### PR TITLE
Remove x86_64-darwin from supported systems

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,6 @@
       "x86_64-linux"
       "aarch64-linux"
       # Darwin systems are supported but not as hosts to deploy to.
-      "x86_64-darwin"
       "aarch64-darwin"
     ];
 


### PR DESCRIPTION
Each flake evaluation now throws:

```
evaluation warning: Nixpkgs 26.05 will be the last release to support x86_64-darwin; see https://nixos.org/manual/nixpkgs/unstable/release-notes#x86_64-darwin-26.05
```

Explicitly remove `x86_64-darwin` to get rid of the warning.