### PR TITLE
Change MaxFileSec from 'day' to '1d'

### DIFF
--- a/modules/configuration.nix
+++ b/modules/configuration.nix
@@ -32,7 +32,7 @@ in
     SystemMaxUse=2G
     SystemKeepFree=4G
     SystemMaxFileSize=100M
-    MaxFileSec=day
+    MaxFileSec=1d
     '';
 
     # hashedPasswordFile only works if users are not mutable.


### PR DESCRIPTION
`day` is invalid syntax, and causes log spam:

```
systemd-journald[838]: /etc/systemd/journald.conf:11: Failed to parse MaxFileSec=day, ignoring: Invalid argument
```

Verification:

```
> systemd-analyze timespan day
Failed to parse time span 'day': Invalid argument
> systemd-analyze timespan 1d
Original: 1d
      μs: 86400000000
   Human: 1d
```