### PR TITLE
Migrate initrd unlock flow to systemd initrd

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -160,45 +160,45 @@ So here, we want to run an ssh server in initrd
 which allows us to unlock the root pool
 and continue the boot process.
 
-The relevant config is in [modules/disks.nix](@REPO@/modules/disks.nix):
+For the default DHCP case, the relevant systemd initrd excerpt is in
+[modules/bootssh.nix](@REPO@/modules/bootssh.nix):
 
 ```nix
+boot.initrd.systemd.network = {
+  enable = true;
+  networks."10-lan" = {
+    matchConfig.Name = "en*";
+    networkConfig.DHCP = "ipv4";
+    linkConfig.RequiredForOnline = true;
+  };
+};
+
 boot.initrd.network = {
   enable = true;
-
-  udhcpc.enable = lib.mkDefault true;
-
   ssh = {
     enable = true;
-    port = lib.mkDefault cfg.boot.sshPort;
-    authorizedKeyFiles = [
-      ./<hostname>/ssh.pub
-    ];
+    port = lib.mkDefault cfg.sshPort;
+    authorizedKeys =
+      map (key: ''command="/bin/systemctl default" ${key}'') config.skarabox.sshAuthorizedKey;
   };
-
-  postCommands = ''
-    zpool import -a
-    echo "zfs load-key ${cfg.rootPool}; killall zfs; exit" >> /root/.profile
-  '';
+};
 ```
 
-We enable `boot.initrd.network` and the `.ssh` options.
-We set the port to 2222 by default.
-We add an ssh public key so we can connect as the root user.
+We enable systemd initrd networking and initrd SSH.
+We set the port to the configured initrd SSH port, which defaults to 2223.
+The regular SSH port defaults to 2222.
+We add ssh public keys with a forced command so successful SSH
+authentication can only run `systemctl default`.
+This excerpt leaves out host key configuration, which is covered in
+[Host Key](#host-key).
 
 This ssh public key is generated as part of the [initialization](@REPO@/lib/gen-initial.nix)
 process in `./<hostname>/ssh.pub` and the private key in `./<hostname>/ssh`.
 We also add that file to `.gitignore` to ensure
 we don't store the private file in the repo.
 
-The commands in `postCommands` are executed when the sshd
-daemon has started. The command added in `/root/.profile` will
-be executed when we log in through SSH.
-This results in ZFS prompting us to enter the
-root zpool's passphrase as soon as we're logged in.
-
-The `udhcpc.enable` option enables DHCP.
-Allowing a static IP here is planned.
+Running `systemctl default` lets the systemd initrd prompt for passphrases
+as necessary while importing the encrypted root pool.
 
 If by any change the kernel does not try to connect to the network
 and fails to ask for an IP and no error message is shown,
@@ -235,12 +235,19 @@ systemd.network = {
 and at boot:
 
 ```nix
-boot.initrd.network.udhcpc.enable = true;
+boot.initrd.systemd.network = {
+  enable = true;
+  networks."10-lan" = {
+    matchConfig.Name = "en*";
+    networkConfig.DHCP = "ipv4";
+    linkConfig.RequiredForOnline = true;
+  };
+};
 ```
 
 On the server, we can use a catch-all `"en*"` setting to
 match all Ethernet connections, which is a nice default.
-At boot, `udhcpc` does that too automatically.
+The same matching is used in the systemd initrd.
 
 If the `skarabox.staticNetwork` is set to for example:
 
@@ -270,38 +277,23 @@ systemd.network = {
 ```
 
 Here also we can use the catch-all `"en*"` setting.
-
-At boot, we disabled `udhcpc`
-and need to set the `boot.kernelParams` option too:
+The systemd initrd gets the same static network configuration:
 
 ```nix
-boot.initrd.network.udhcpc.enable = false;
-
-boot.kernelParams = let
-  cfg' = config.skarabox.staticNetwork;
-in [
-  "ip=${cfg'.ip}::${cfg'.gateway}:255.255.255.0:${config.skarabox.hostname}-initrd:${cfg'.deviceName}:off:::"
-];
+boot.initrd.systemd.network = {
+  enable = true;
+  networks."10-lan" = {
+    matchConfig.Name = "en*";
+    address = [
+      "${config.skarabox.staticNetwork.ip}/24"
+    ];
+    routes = [
+      { Gateway = config.skarabox.staticNetwork.gateway; }
+    ];
+    linkConfig.RequiredForOnline = true;
+  };
+};
 ```
-
-A big difference here is we cannot use a catch-all setting for all Ethernet devices.
-So instead we must know which interface name to bind to.
-To avoid doing that, we'll use the `facter.json` report to extract
-the interface name we want to bind to:
-
-```nix
-skarabox.staticNetwork.deviceName = let
-  cfg' = cfg.staticNetwork;
-
-  fn = n: n.sub_class.name == "Ethernet" && lib.hasPrefix cfg'.device.namePrefix n.unix_device_names;
-
-  firstMatchingDevice = (builtins.head (builtins.filter fn config.hardware.facter.report.hardware.network_interface)).unix_device_names;
-in
-  if isString cfg'.device then cfg'.device else firstMatchingDevice;
-```
-
-The option `device.namePrefix` is used to distinguish between
-Ethernet and Wireless interfaces.
 
 On the beacon, we always use a static IP address to make sure
 it will match with the one the server will have. This way,
@@ -353,8 +345,8 @@ For the initrd ssh access, to decrypt the root partition,
 the configuration is similar although here the user is `root`:
 
 ```nix
-boot.initrd.network = {
-  ssh.authorizedKeys = config.skarabox.sshAuthorizedKeys;
+boot.initrd.network.ssh = {
+  authorizedKeys = map (key: ''command="/bin/systemctl default" ${key}'') config.skarabox.sshAuthorizedKeys;
 };
 ```
 
@@ -393,9 +385,21 @@ This snapshot is thus empty.
 Now, we revert back to the snapshot upon every boot with:
 
 ```nix
-boot.initrd.postResumeCommands = lib.mkAfter ''
-  zfs rollback -r ${cfg.rootPool}/local/root@blank
-'';
+boot.initrd.systemd.services.skarabox-rollback-root = {
+  description = "Rollback impermanent root dataset";
+  # NixOS' ZFS module imports the root pool in this generated service.
+  # The rollback can only run after the pool is available.
+  after = [ "zfs-import-${cfg.rootPool.name}.service" ];
+  before = [ "sysroot.mount" ];
+  requiredBy = [ "sysroot.mount" ];
+  # Match the generated ZFS import unit's early initrd ordering.
+  unitConfig.DefaultDependencies = false;
+  serviceConfig.Type = "oneshot";
+  path = [ config.boot.zfs.package ];
+  script = ''
+    zfs rollback -r ${cfg.rootPool.name}/local/root@blank
+  '';
+};
 ```
 
 To save a directory, we must create a dataset and mount it:

--- a/flakeModules/default.nix
+++ b/flakeModules/default.nix
@@ -582,11 +582,11 @@ in
               boot-ssh
             ];
 
-            # systemd initrd prompts for the ZFS key through the TTY password agent.
-            # -tt forces TTY allocation even though the passphrase is piped on stdin.
+            # skarabox-unlock-root answers systemd's ask-password request directly,
+            # so this path must not allocate a TTY that could echo the passphrase.
             text = ''
               root_passphrase="$(sops decrypt --extract "${cfg'.secretsRootPassphrasePath}" "${cfg'.secretsFilePath}")"
-              printf '%s\n' "$root_passphrase" | boot-ssh -tt "$@"
+              printf '%s\n' "$root_passphrase" | boot-ssh -T "$@"
             '';
           };
         in {

--- a/flakeModules/default.nix
+++ b/flakeModules/default.nix
@@ -24,7 +24,6 @@ let
         skarabox.sshAuthorizedKeys = hostCfg.skarabox.sshAuthorizedKeys;
         skarabox.sshPort = hostCfg.skarabox.sshPort;
         skarabox.hotspot.ip = lib.mkIf (hostCfg.skarabox.staticNetwork != null) hostCfg.skarabox.staticNetwork.ip;
-        boot.initrd.network.udhcpc.enable = hostCfg.skarabox.staticNetwork == null;
       }
     ];
   };
@@ -278,9 +277,7 @@ in
       mkHostPackages = name: cfg': let
         hostCfg = topLevelConfig.flake.nixosConfigurations.${name}.config;
 
-        # nix run .#boot-ssh [<command> ...]
         # nix run .#boot-ssh
-        # nix run .#boot-ssh echo hello
         boot-ssh = pkgs.writeShellApplication {
           name = "boot-ssh";
 
@@ -585,9 +582,11 @@ in
               boot-ssh
             ];
 
+            # systemd initrd prompts for the ZFS key through the TTY password agent.
+            # -tt forces TTY allocation even though the passphrase is piped on stdin.
             text = ''
               root_passphrase="$(sops decrypt --extract "${cfg'.secretsRootPassphrasePath}" "${cfg'.secretsFilePath}")"
-              printf '%s' "$root_passphrase" | boot-ssh -T "$@"
+              printf '%s\n' "$root_passphrase" | boot-ssh -tt "$@"
             '';
           };
         in {

--- a/modules/beacon.nix
+++ b/modules/beacon.nix
@@ -155,8 +155,7 @@ in {
 
     boot.loader.systemd-boot.enable = true;
 
-    # Skarabox does not support systemd in stage1 yet.
-    boot.initrd.systemd.enable = false;
+    boot.initrd.systemd.enable = true;
 
     environment.systemPackages = let
       skarabox-help = pkgs.writeText "skarabox-help" helptext;

--- a/modules/bootssh.nix
+++ b/modules/bootssh.nix
@@ -1,8 +1,81 @@
-{ config, lib, ... }:
+{ config, lib, pkgs, ... }:
 let
   cfg = config.skarabox.boot;
 
-  inherit (lib) mkOption optionals types;
+  inherit (lib) getExe mkOption optionals types;
+
+  replyPassword = "${config.boot.initrd.systemd.package}/lib/systemd/systemd-reply-password";
+
+  unlockRootNonTty = pkgs.writeShellApplication {
+    name = "skarabox-unlock-root-non-tty";
+
+    text = ''
+      # Without a TTY, stdin is the passphrase from the generated unlock command.
+      # Read it before talking to systemd so it cannot be echoed by any terminal
+      # password prompt.
+      if ! IFS= read -r passphrase; then
+        echo "No root passphrase received." >&2
+        exit 1
+      fi
+
+      # Queue the same "continue booting" transaction as above. `--no-block` is
+      # required because boot will stop at the root-key prompt; this script has
+      # to keep running so it can answer that prompt.
+      /bin/systemctl --no-block default
+
+      # systemd publishes pending password requests as ask.* files under
+      # /run/systemd/ask-password. Each file describes one prompt and contains a
+      # Socket= field naming the Unix socket where password agents should reply.
+      attempts=0
+      while [ "$attempts" -lt 60 ]; do
+        for request in /run/systemd/ask-password/ask.*; do
+          if [ ! -e "$request" ]; then
+            continue
+          fi
+
+          socket=
+          while IFS='=' read -r key value; do
+            if [ "$key" = Socket ]; then
+              socket=$value
+              break
+            fi
+          done < "$request"
+
+          if [ -n "$socket" ]; then
+            # systemd-reply-password is systemd's ask-password protocol helper.
+            # It reads one line from stdin and sends it to the Socket= endpoint.
+            if printf '%s\n' "$passphrase" | ${replyPassword} 1 "$socket"; then
+              echo "Root unlock successful; continuing boot."
+              exit 0
+            fi
+          fi
+        done
+
+        attempts=$((attempts + 1))
+        sleep 1
+      done
+
+      echo "Timed out waiting for a systemd password request." >&2
+      exit 1
+    '';
+  };
+
+  unlockRoot = pkgs.writeShellApplication {
+    name = "skarabox-unlock-root";
+
+    text = ''
+      # An SSH session with a TTY is the manual unlock path. `systemctl default`
+      # asks the initrd systemd manager to continue booting by starting its
+      # default target. With a TTY attached, the normal systemd password prompt
+      # can use the SSH terminal, so hand the session over to systemctl.
+      if [ -t 0 ]; then
+        exec /bin/systemctl default
+      else
+        exec ${getExe unlockRootNonTty}
+      fi
+    '';
+  };
+
 in
 {
   options.skarabox.boot = {
@@ -36,6 +109,12 @@ in
       };
     });
 
+    boot.initrd.systemd.storePaths = [
+      unlockRoot
+      unlockRootNonTty
+      replyPassword
+    ];
+
     boot.initrd.network = {
       enable = true;
       ssh = {
@@ -45,7 +124,7 @@ in
         port = lib.mkDefault cfg.sshPort;
         hostKeys = lib.mkForce ([ "/boot/host_key" ] ++ (optionals (config.skarabox.disks.rootPool.disk2 != null) [ "/boot-backup/host_key" ]));
         # Only allow remote unlocks, not arbitrary initrd commands.
-        authorizedKeys = map (key: ''command="/bin/systemctl default" ${key}'') config.skarabox.sshAuthorizedKeys;
+        authorizedKeys = map (key: ''command="${getExe unlockRoot}" ${key}'') config.skarabox.sshAuthorizedKeys;
       };
     };
   };

--- a/modules/bootssh.nix
+++ b/modules/bootssh.nix
@@ -14,14 +14,29 @@ in
   };
 
   config = {
-    # Enables DHCP in stage-1 even if networking.useDHCP is false.
-    boot.initrd.network.udhcpc.enable = lib.mkDefault (config.skarabox.staticNetwork == null);
-    # From https://wiki.nixos.org/wiki/ZFS#Remote_unlock
+    # Keep this in sync with the stage-2 networkd config in ./network.nix.
+    boot.initrd.systemd.network = {
+      enable = true;
+    } // (if config.skarabox.staticNetwork == null then {
+      networks."10-lan" = {
+        matchConfig.Name = "en*";
+        networkConfig.DHCP = "ipv4";
+        linkConfig.RequiredForOnline = true;
+      };
+    } else {
+      networks."10-lan" = {
+        matchConfig.Name = "en*";
+        address = [
+          "${config.skarabox.staticNetwork.ip}/24"
+        ];
+        routes = [
+          { Gateway = config.skarabox.staticNetwork.gateway; }
+        ];
+        linkConfig.RequiredForOnline = true;
+      };
+    });
+
     boot.initrd.network = {
-      # This will use udhcp to get an ip address. Nixos-facter should have found the correct drivers
-      # to load but in case not, they need to be added to `boot.initrd.availableKernelModules`.
-      # Static ip addresses might be configured using the ip argument in kernel command line:
-      # https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt
       enable = true;
       ssh = {
         enable = true;
@@ -29,22 +44,9 @@ in
         # a different port for ssh is used.
         port = lib.mkDefault cfg.sshPort;
         hostKeys = lib.mkForce ([ "/boot/host_key" ] ++ (optionals (config.skarabox.disks.rootPool.disk2 != null) [ "/boot-backup/host_key" ]));
-        # Public SSH keys used for login.
-        authorizedKeys = config.skarabox.sshAuthorizedKeys;
+        # Only allow remote unlocks, not arbitrary initrd commands.
+        authorizedKeys = map (key: ''command="/bin/systemctl default" ${key}'') config.skarabox.sshAuthorizedKeys;
       };
-
-      postCommands = ''
-      zpool import -a
-      echo "zfs load-key ${config.skarabox.disks.rootPool.name}; killall zfs; exit" >> /root/.profile
-      '';
     };
-
-    boot.kernelParams = lib.optionals (config.skarabox.staticNetwork != null && config.hardware.facter.report != {}) (let
-      cfg' = config.skarabox.staticNetwork;
-    in [
-      # https://www.kernel.org/doc/Documentation/filesystems/nfs/nfsroot.txt
-      # ip=<client-ip>:<server-ip>:<gw-ip>:<netmask>:<hostname>:<device>:<autoconf>:<dns0-ip>:<dns1-ip>:<ntp0-ip>
-      "ip=${cfg'.ip}::${cfg'.gateway}:255.255.255.0:${config.skarabox.hostname}-initrd:${cfg'.deviceName}:off:::"
-    ]);
   };
 }

--- a/modules/configuration.nix
+++ b/modules/configuration.nix
@@ -54,8 +54,7 @@ in
       }
     ];
 
-    # Skarabox does not support systemd in stage1 yet.
-    boot.initrd.systemd.enable = false;
+    boot.initrd.systemd.enable = true;
 
     environment.systemPackages = [
       pkgs.vim

--- a/modules/disks.nix
+++ b/modules/disks.nix
@@ -363,9 +363,36 @@ in
 
     # Follows https://grahamc.com/blog/erase-your-darlings/
     # https://github.com/NixOS/nixpkgs/pull/346247/files
-    boot.initrd.postResumeCommands = lib.mkAfter ''
-      zfs rollback -r ${cfg.rootPool.name}/local/root@blank
-    '';
+    boot.initrd.systemd.services.skarabox-rollback-root = {
+      description = "Rollback impermanent root dataset";
+      # NixOS' ZFS module imports the root pool in this generated service.
+      # The rollback can only run after the pool is available.
+      after = [ "zfs-import-${cfg.rootPool.name}.service" ];
+      before = [ "sysroot.mount" ];
+      requiredBy = [ "sysroot.mount" ];
+      # Match the generated ZFS import unit's early initrd ordering.
+      unitConfig.DefaultDependencies = false;
+      serviceConfig = {
+        Type = "oneshot";
+        # Ordering:
+        # 1. zfs-import-root.service waits for the encrypted pool to be unlocked.
+        # 2. sysroot.mount requires this service, and Before=sysroot.mount orders
+        #    the rollback after import but before /sysroot is mounted.
+        # 3. /sysroot submounts are mounted.
+        # 4. initrd-nixos-activation.service has RequiresMountsFor=/sysroot/run,
+        #    so systemd later creates another transaction that ensures
+        #    sysroot.mount and its requirements are available before activation.
+        # A plain oneshot is inactive after ExecStart exits, so that later
+        # transaction can run the rollback a second time after /sysroot submounts
+        # already exist. Keep it active (exited) to record that rollback already
+        # ran this boot.
+        RemainAfterExit = true;
+      };
+      path = [ config.boot.zfs.package ];
+      script = ''
+        zfs rollback -r ${cfg.rootPool.name}/local/root@blank
+      '';
+    };
 
     # Setup Grub to support UEFI.
     # nodev is for UEFI.

--- a/modules/network.nix
+++ b/modules/network.nix
@@ -84,11 +84,11 @@ in
   config = lib.mkIf (!cfg.disableNetworkSetup) {
     assertions = [
       {
-        assertion = cfg.staticNetwork == null -> config.boot.initrd.network.udhcpc.enable;
+        assertion = !config.boot.initrd.network.ssh.enable || cfg.staticNetwork != null || config.boot.initrd.systemd.network.enable;
         message = ''
-          If DHCP is disabled and an IP is not set, the box will not be reachable through the network on boot and you will not be able to enter the passphrase through SSH.
+          Initrd SSH is enabled, but no static IP is set and initrd systemd networking is disabled. The box will not be reachable through the network on boot and you will not be able to enter the passphrase through SSH.
 
-          To fix this error, either set config.boot.initrd.network.udhcpc.enable = true or give an IP to skarabox.staticNetwork.ip.
+          To fix this error, set config.boot.initrd.systemd.network.enable = true, give an IP to skarabox.staticNetwork.ip, or disable config.boot.initrd.network.ssh.enable if remote unlock is not required.
         '';
       }
     ];
@@ -96,6 +96,7 @@ in
     # Removing this line shows a warning that the current configuration
     # leads to network interfaces managed by both systemd and a custom NixOS script.
     networking.useNetworkd = true;
+    # Keep this in sync with the initrd networkd config in ./bootssh.nix.
     systemd.network = (
       {
         enable = true;

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -264,11 +264,14 @@ in
         })
       ];
     };
+    authorizedKeys = nixos.config.boot.initrd.network.ssh.authorizedKeys;
+    authorizedKey = pkgs.lib.head authorizedKeys;
+    authorizedKeyMatch = builtins.match ''command="/nix/store/[a-z0-9]+-skarabox-unlock-root/bin/skarabox-unlock-root" (.*)'' authorizedKey;
   in {
-    expected = [
-      ''command="/bin/systemctl default" ${singleKey}''
-    ];
-    expr = nixos.config.boot.initrd.network.ssh.authorizedKeys;
+    expected = true;
+    expr =
+      pkgs.lib.length authorizedKeys == 1
+      && authorizedKeyMatch == [ singleKey ];
   };
 
   testMultiHostSameArch = let

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -240,6 +240,37 @@ in
     expr = evalSshAuthorizedKey [ singleKey ];
   };
 
+  testBootsshTrimsNewlineTerminatedAuthorizedKey = let
+    nixos = import (pkgs.path + "/nixos/lib/eval-config.nix") {
+      inherit (pkgs) system;
+      modules = [
+        ../modules/options.nix
+        ../modules/bootssh.nix
+        ({ lib, ... }: {
+          options.skarabox.staticNetwork = lib.mkOption {
+            type = with lib.types; nullOr attrs;
+            default = null;
+          };
+
+          options.skarabox.disks.rootPool.disk2 = lib.mkOption {
+            type = with lib.types; nullOr str;
+            default = null;
+          };
+
+          config = {
+            skarabox.sshAuthorizedKey = singleKeyFile;
+            system.stateVersion = "26.11";
+          };
+        })
+      ];
+    };
+  in {
+    expected = [
+      ''command="/bin/systemctl default" ${singleKey}''
+    ];
+    expr = nixos.config.boot.initrd.network.ssh.authorizedKeys;
+  };
+
   testMultiHostSameArch = let
     # Create minimal test flake using the actual skarabox flakeModule
     dummy = pkgs.writeText "dummy" "";

--- a/tests/static.nix
+++ b/tests/static.nix
@@ -130,15 +130,11 @@
     ${nix} run .#myskarabox-install-on-beacon -- --no-substitute-on-destination
     endgroup "Installation succeeded."
 
-    group "Starting ssh loop to figure out when VM is ready to receive root passphrase."
+    group "Starting unlock loop to decrypt root dataset."
     e "You might see some flickering on the command line."
-    while ! ${nix} run .#myskarabox-boot-ssh -- -F none echo "connected"; do
+    while ! ${nix} run .#myskarabox-unlock -- -F none; do
       sleep 5
     done
-    endgroup "Beacon VM is ready to accept root passphrase."
-
-    group "Decrypting root dataset."
-    ${nix} run .#myskarabox-unlock -- -F none
     endgroup "Decryption done."
 
     group "Starting ssh loop to figure out when VM has booted."

--- a/tests/variants.nix
+++ b/tests/variants.nix
@@ -163,15 +163,11 @@ let
     ${nix} run .#myskarabox-install-on-beacon -- --no-substitute-on-destination
     endgroup "Installation succeeded."
 
-    group "Starting ssh loop to figure out when VM is ready to receive root passphrase."
+    group "Starting unlock loop to decrypt root dataset."
     e "You might see some flickering on the command line."
-    while ! ${nix} run .#myskarabox-boot-ssh -- -F none echo "connected"; do
+    while ! ${nix} run .#myskarabox-unlock -- -F none; do
       sleep 5
     done
-    endgroup "Beacon VM is ready to accept root passphrase."
-
-    group "Decrypting root dataset."
-    ${nix} run .#myskarabox-unlock -- -F none
     endgroup "Decryption done."
 
     group "Starting ssh loop to figure out when VM has booted."
@@ -207,15 +203,11 @@ let
     ${nix} run .#myskarabox-ssh -- -F none "(sleep 2 && sudo reboot)&"
     endgroup "Rebooting in progress."
 
-    group "Starting ssh loop to figure out when VM is ready to receive root passphrase."
+    group "Starting unlock loop to decrypt root dataset."
     e "You might see some flickering on the command line."
-    while ! ${nix} run .#myskarabox-boot-ssh -- -F none echo "connected"; do
+    while ! ${nix} run .#myskarabox-unlock -- -F none; do
       sleep 5
     done
-    endgroup "Beacon VM is ready to accept root passphrase."
-
-    group "Decrypting root dataset."
-    ${nix} run .#myskarabox-unlock -- -F none
     endgroup "Decryption done."
 
     group "Starting ssh loop to figure out when VM has booted."


### PR DESCRIPTION
Enable systemd initrd for hosts and beacons, and move initrd networking to boot.initrd.systemd.network. This replaces the scripted initrd SSH unlock flow based on postCommands, zpool import, and a root .profile hook with a forced SSH command that resumes the systemd initrd boot transaction.

Move the impermanent root rollback from postResumeCommands into an initrd systemd service ordered after the generated ZFS import unit and before sysroot.mount.

Update the unlock command to allocate a TTY for the systemd password agent, adjust the network assertion for systemd initrd networking, and update affected tests and architecture docs.