### PR TITLE
Add sudo to fdisk command in installation instructions

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -288,7 +288,7 @@ $ nix run .#myskarabox-install-on-beacon -- --phases kexec
 2. Print the disk layout
 
 ```bash
-$ nix run .#myskarabox-ssh-beacon -- fdisk -l
+$ nix run .#myskarabox-ssh-beacon -- sudo fdisk -l
 $ nix run .#myskarabox-ssh-beacon -- lsblk
 ```
 


### PR DESCRIPTION
Updated the fdisk command to include 'sudo'. Otherwise the command fails with messages like:

```
fdisk: cannot open /dev/device_name: Permission denied
```