### PR TITLE
Fix local template test initialization

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -47,7 +47,7 @@
     perSystem = { self', inputs', pkgs, system, ... }: {
       packages = rec {
         # Usage:
-        #  init [-h] [-y] [-s] [-v] [-p PATH]
+        #  init [-h] [-y] [-s] [-v]
         #
         # printasdf help:
         #  init -h

--- a/lib/gen-initial.nix
+++ b/lib/gen-initial.nix
@@ -28,27 +28,22 @@ pkgs.writeShellApplication {
 
     name=myskarabox
     yes=0
-    path=
     verbose=
 
     usage () {
       cat <<USAGE
-Usage: $0 [-h] [-n] [-y] [-s] [-v] [-p PATH]
+Usage: $0 [-h] [-n] [-y] [-s] [-v]
 
   -h:        Shows this usage
   -y:        Answer yes to all questions
   -s:        Take user password from stdin. Only useful
              in scripts.
-  -p PATH:   Replace occurences of github:ibizaman/skarabox
-             with the given path, for example ../skarabox.
-             This is useful for testing with your own fork
-             of skarabox.
   -v:        Shows what commands are being run.
 USAGE
     }
 
     args=()
-    while getopts ":hn:ysp:v" o; do
+    while getopts ":hn:ysv" o; do
       case "''${o}" in
         h)
           usage
@@ -60,9 +55,6 @@ USAGE
           ;;
         s)
           args+=(-s)
-          ;;
-        p)
-          path=''${OPTARG}
           ;;
         v)
           args+=(-v)
@@ -110,10 +102,6 @@ USAGE
     fi
 
     ${nix} flake init --template ${../.}
-
-    if [ -n "$path" ]; then
-      ${nix} flake update --override-input skarabox "$path" skarabox
-    fi
 
     e "Now, we will generate the global secrets."
 

--- a/tests/static.nix
+++ b/tests/static.nix
@@ -58,10 +58,9 @@
     cd $tmpdir
 
     group "Initialising template"
-    echo skarabox1234 | ${nix} run ${../.}#init -- -v -y -s -p ${../.}
+    echo skarabox1234 | ${nix} run ${../.}#init -- -v -y -s
     sed -i "s/\(ip =\) \"192.168.1.30\"/\1 \"127.0.0.1\"/" "flake.nix"
     sed -i "s/\(system =\) \"x86_64-linux\"/\1 \"${system}\"/" "flake.nix"
-    ${nix} run .#myskarabox-gen-knownhosts-file
     # Using a git repo here allows to only copy in the nix store non temporary files.
     # In particular, we avoid copying the disk*.qcow2 files.
     git init
@@ -70,6 +69,12 @@
     git config user.name "skarabox"
     git config user.email "skarabox@skarabox.com"
     git commit -m 'init repository'
+    ${nix} flake update --override-input skarabox ${../.} skarabox
+    git add flake.lock
+    git commit -m 'use local skarabox input'
+    ${nix} run .#myskarabox-gen-knownhosts-file
+    git add ./myskarabox/known_hosts
+    git commit -m 'generate known hosts'
     endgroup "Initialisation done"
 
     sed -i 's-staticNetwork = null-staticNetwork = { ip="10.0.2.15"; gateway="10.0.2.255"; }-' ./myskarabox/configuration.nix

--- a/tests/variants.nix
+++ b/tests/variants.nix
@@ -73,7 +73,7 @@ let
     cd $tmpdir
 
     group "Initialising template"
-    echo skarabox1234 | ${nix} run ${../.}#init -- -v -y -s -p ${../.}
+    echo skarabox1234 | ${nix} run ${../.}#init -- -v -y -s
     sed -i "s/\(ip =\) \"192.168.1.30\"/\1 \"127.0.0.1\"/" "flake.nix"
     sed -i "s/\(system =\) \"x86_64-linux\"/\1 \"${system}\"/" "flake.nix"
     if [ "$legacyNixpkgs" = true ]; then
@@ -82,7 +82,6 @@ let
     fi
     sed -i "s/\(skarabox.sshPort =\) 2222/\1 $sshPort/" "./myskarabox/configuration.nix"
     sed -i "s/\(skarabox.boot.sshPort =\) 2223/\1 $sshBootPort/" "./myskarabox/configuration.nix"
-    ${nix} run .#myskarabox-gen-knownhosts-file --show-trace
 
     if grep -R "I'm empty and in plain text right now" .; then
       echo "Failed to replace secrets file, fix the templating."
@@ -97,6 +96,13 @@ let
     git config user.name "skarabox"
     git config user.email "skarabox@skarabox.com"
     git commit -m 'init repository'
+    ${nix} flake update --override-input skarabox ${../.} skarabox
+    git add flake.lock
+    git commit -m 'use local skarabox input'
+    ${nix} run .#myskarabox-gen-knownhosts-file --show-trace
+    git add ./myskarabox/known_hosts
+    git commit -m 'generate known hosts'
+
     endgroup "Initialisation done"
 
     if [ "$dataPool" = false ]; then


### PR DESCRIPTION
The VM template tests used `#init -p` to make the generated repository point back at the local checkout. With current Nix Git resolution, updating that generated flake before it is a Git repository can resolve through `/tmp` and fail.

Remove the `#init -p` shortcut, since it is equivalent to running `#init` and then overriding the generated repository's skarabox input. The tests now initialize and commit the generated repository first, override skarabox to the local checkout, commit the lock update, and then generate `known_hosts`.

Error before this patch, running at the root of the git checkout:

```
> nix run .#checks.x86_64-linux.staticIP
SKARABOX-TEMPLATE: Creating tmpdir
SKARABOX-TEMPLATE: Created temp dir at /tmp/tmp.lNHqQ22LT4, will be cleaned up on exit or abort
SKARABOX-TEMPLATE: Done creating tmpdir
SKARABOX-TEMPLATE: Initialising template
+ e 'This script will initiate a Skarabox template in the current directory.'
+ echo -e '\e[1;31mSKARABOX:\e[0m \e[1;0mThis script will initiate a Skarabox template in the current directory.\e[0m'
SKARABOX: This script will initiate a Skarabox template in the current directory.
+ yes_or_no 'Most of the steps are automatic but there are some instructions you'\''ll need to follow manually at the end, continue?'
+ true
+ echo -ne '\e[1;31mSKARABOX:\e[0m '
SKARABOX: + '[' 1 -eq 1 ']'
+ echo 'Most of the steps are automatic but there are some instructions you'\''ll need to follow manually at the end, continue? Forced yes'
Most of the steps are automatic but there are some instructions you'll need to follow manually at the end, continue? Forced yes
+ return 0
++ find . -mindepth 1
++ wc -l
+ '[' 0 -gt 0 ']'
+ nix --extra-experimental-features nix-command -L flake init --template /nix/store/11yrl2qkm64z9cixy15n1fznisphgb7d-k3n0sh6s0m81dmpbp2gk5sc0qcxwk35z-source
wrote: "/tmp/tmp.lNHqQ22LT4/.gitignore"
wrote: "/tmp/tmp.lNHqQ22LT4/.sops.yaml"
wrote: "/tmp/tmp.lNHqQ22LT4/README.md"
wrote: "/tmp/tmp.lNHqQ22LT4/flake.lock"
wrote: "/tmp/tmp.lNHqQ22LT4/flake.nix"
wrote: "/tmp/tmp.lNHqQ22LT4/myskarabox/configuration.nix"
wrote: "/tmp/tmp.lNHqQ22LT4/myskarabox/host_key"
wrote: "/tmp/tmp.lNHqQ22LT4/myskarabox/known_hosts"
wrote: "/tmp/tmp.lNHqQ22LT4/myskarabox/secrets.yaml"
wrote: "/tmp/tmp.lNHqQ22LT4/myskarabox"
wrote: "/tmp/tmp.lNHqQ22LT4/sops.key"
+ '[' -n /nix/store/11yrl2qkm64z9cixy15n1fznisphgb7d-k3n0sh6s0m81dmpbp2gk5sc0qcxwk35z-source ']'
+ nix --extra-experimental-features nix-command -L flake update --override-input skarabox /nix/store/11yrl2qkm64z9cixy15n1fznisphgb7d-k3n0sh6s0m81dmpbp2gk5sc0qcxwk35z-source skarabox
error:
       … while fetching the input 'git+file:///tmp'

       error: opening Git repository "/tmp": could not find repository at '/tmp' (libgit2 error code = 6)
```