### PR TITLE
Fix VM test cleanup process group

### DIFF
--- a/tests/default.nix
+++ b/tests/default.nix
@@ -3,6 +3,7 @@ let
   # It is necessary to add --allow-import-from-derivation explicitly because the flake show command
   # does not pick it up from the config, on purpose.
   nix = "${pkgs.nix}/bin/nix --allow-import-from-derivation --extra-experimental-features nix-command -L";
+  setsid = "${pkgs.util-linux}/bin/setsid";
 
 in
 {
@@ -11,5 +12,5 @@ in
     tests = pkgs.callPackage ./lib.nix {};
   };
 }
-// (import ./variants.nix { inherit system nix; inherit (pkgs) gnugrep jq writeShellScriptBin; })
-// (import ./static.nix { inherit system nix; inherit (pkgs) jq writeShellScriptBin; })
+// (import ./variants.nix { inherit system nix setsid; inherit (pkgs) gnugrep jq writeShellScriptBin; })
+// (import ./static.nix { inherit system nix setsid; inherit (pkgs) jq writeShellScriptBin; })

--- a/tests/static.nix
+++ b/tests/static.nix
@@ -1,4 +1,4 @@
-{ system, nix, jq, writeShellScriptBin }:
+{ system, nix, jq, setsid, writeShellScriptBin }:
 {
   staticIP = writeShellScriptBin "staticIP" ''
     set -e
@@ -26,6 +26,30 @@
 
     graphic=-nographic
     tmpdir=
+    remove_tmpdir=false
+    beacon_vm_pid=
+
+    cleanup () {
+      status="$1"
+      # Disable traps while cleaning up so cleanup does not recursively call itself.
+      trap - INT TERM EXIT
+
+      if [ -n "$beacon_vm_pid" ]; then
+        # A leading '-' makes kill signal that process group, not just that PID.
+        kill -- "-$beacon_vm_pid" 2>/dev/null || true
+        wait "$beacon_vm_pid" 2>/dev/null || true
+      fi
+
+      if [ "$remove_tmpdir" = true ]; then
+        rm -rf -- "$tmpdir"
+      fi
+
+      exit "$status"
+    }
+    # Preserve the original exit status, and use conventional statuses for signals.
+    trap 'cleanup $?' EXIT
+    trap 'cleanup 130' INT
+    trap 'cleanup 143' TERM
 
     while getopts "gp:" o; do
       case "''${o}" in
@@ -45,17 +69,13 @@
     if [ -z "$tmpdir" ]; then
       group "Creating tmpdir"
       tmpdir="$(mktemp -d)"
+      remove_tmpdir=true
       e "Created temp dir at $tmpdir, will be cleaned up on exit or abort"
-
-      # Kills all children bash processes,
-      # like the one that will run in the background hereunder.
-      # https://stackoverflow.com/a/2173421/1013628
-      trap "rm -rf $tmpdir/* $tmpdir/.* $tmpdir; trap - SIGTERM && kill -- -$$ || :" SIGINT SIGTERM EXIT
       endgroup "Done creating tmpdir"
     else
-      e "Using provided temp dir $tmpdir, nothing will be cleaned up"
+      e "Using provided temp dir $tmpdir, it will not be cleaned up"
     fi
-    cd $tmpdir
+    cd "$tmpdir"
 
     group "Initialising template"
     echo skarabox1234 | ${nix} run ${../.}#init -- -v -y -s
@@ -85,7 +105,8 @@
 
     e "Starting beacon VM."
 
-    ${nix} run .#myskarabox-beacon-vm -- $graphic &
+    ${setsid} ${nix} run .#myskarabox-beacon-vm -- $graphic &
+    beacon_vm_pid=$!
 
     sleep 10
 

--- a/tests/variants.nix
+++ b/tests/variants.nix
@@ -1,4 +1,4 @@
-{ system, nix, gnugrep, jq, writeShellScriptBin }:
+{ system, nix, gnugrep, jq, setsid, writeShellScriptBin }:
 let
   toBashBool = v: if v then "true" else "false";
 
@@ -35,11 +35,35 @@ let
 
     graphic=-nographic
     tmpdir=
+    remove_tmpdir=false
+    beacon_vm_pid=
     rootDisk2=${toBashBool rootDisk2}
     dataPool=${toBashBool dataPool}
     legacyNixpkgs=${toBashBool legacyNixpkgs}
     sshPort=${toString sshPort}
     sshBootPort=${toString sshBootPort}
+
+    cleanup () {
+      status="$1"
+      # Disable traps while cleaning up so cleanup does not recursively call itself.
+      trap - INT TERM EXIT
+
+      if [ -n "$beacon_vm_pid" ]; then
+        # A leading '-' makes kill signal that process group, not just that PID.
+        kill -- "-$beacon_vm_pid" 2>/dev/null || true
+        wait "$beacon_vm_pid" 2>/dev/null || true
+      fi
+
+      if [ "$remove_tmpdir" = true ]; then
+        rm -rf -- "$tmpdir"
+      fi
+
+      exit "$status"
+    }
+    # Preserve the original exit status, and use conventional statuses for signals.
+    trap 'cleanup $?' EXIT
+    trap 'cleanup 130' INT
+    trap 'cleanup 143' TERM
 
     while getopts "gp:" o; do
       case "''${o}" in
@@ -60,17 +84,13 @@ let
     if [ -z "$tmpdir" ]; then
       group "Creating tmpdir"
       tmpdir="$(mktemp -d)"
+      remove_tmpdir=true
       e "Created temp dir at $tmpdir, will be cleaned up on exit or abort"
-
-      # Kills all children bash processes,
-      # like the one that will run in the background hereunder.
-      # https://stackoverflow.com/a/2173421/1013628
-      trap "rm -rf $tmpdir/* $tmpdir/.* $tmpdir; trap - SIGTERM && kill -- -$$ || :" SIGINT SIGTERM EXIT
       endgroup "Done creating tmpdir"
     else
-      e "Using provided temp dir $tmpdir, nothing will be cleaned up"
+      e "Using provided temp dir $tmpdir, it will not be cleaned up"
     fi
-    cd $tmpdir
+    cd "$tmpdir"
 
     group "Initialising template"
     echo skarabox1234 | ${nix} run ${../.}#init -- -v -y -s
@@ -118,7 +138,8 @@ let
 
     e "Starting beacon VM."
 
-    ${nix} run .#myskarabox-beacon-vm -- $graphic &
+    ${setsid} ${nix} run .#myskarabox-beacon-vm -- $graphic &
+    beacon_vm_pid=$!
 
     sleep 10
 


### PR DESCRIPTION
The old EXIT trap is reproducibly unsafe when the test shell is a process-group leader:

    trap "rm -rf $tmpdir/* $tmpdir/.* $tmpdir; trap - SIGTERM && kill -- -$$ || :" SIGINT SIGTERM EXIT

A minimal reproduction is:

    setsid --wait bash -c 'set -e; trap "trap - TERM && kill -- -$$ || :" EXIT; printf "script completed before cleanup\n"'

    printf 'outer exit=%s\n' "$?"

That command prints the success marker and then fails because the trap terminates its own process group with SIGTERM. Depending on how `setsid` and the shell report signal termination, the observed status can be 15 or 143.

`trap - SIGTERM` clears the SIGTERM trap so cleanup does not recurse after signalling.

`kill -- -$$` sends the signal to process group `$$`, not just to process `$$`.

`setsid` starts the command in a new session/process group, giving cleanup a group scoped to the VM.

`setsid --wait` makes the reproduction observe the child exit status even when interactive job control makes `setsid` fork first.

Launch the beacon VM under `setsid`, record its PID, and have cleanup kill only that VM process group while preserving the test exit status.