### PR TITLE
Do not pin Python version for ruamel-yaml to enable `nix flake update`

### DIFF
--- a/lib/add-sops-cfg.nix
+++ b/lib/add-sops-cfg.nix
@@ -4,7 +4,7 @@
 pkgs.writers.writePython3Bin "add-sops-cfg"
   {
     libraries = [
-      pkgs.python313Packages.ruamel-yaml
+      pkgs.python3Packages.ruamel-yaml
     ];
   }
   ''


### PR DESCRIPTION
https://github.com/NixOS/nixpkgs/pull/521373 bumped Python from 3.13 to 3.14. Remove pinned version from `ruamel-yaml` to enable that upgrade.