### PR TITLE
Deprecate target sshAuthorizedKey option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Template:
 
 # Upcoming Release
 
+## User Facing Backwards Compatible Changes
+
+- Deprecated `skarabox.sshAuthorizedKey` in favor of
+  `skarabox.sshAuthorizedKeys`, which accepts a list of non-empty, single-line
+  SSH public key strings or paths to files containing one such key. This change
+  applies only to target hosts; the beacon's `skarabox.sshAuthorizedKey` option
+  is unchanged.
+
 # v1.6.0
 
 ## Breaking Changes

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -345,9 +345,7 @@ to the `authorizedKeys` file of the user:
 
 ```nix
 users.users.${config.skarabox.username} = {
-  openssh.authorizedKeys.keys = [
-    config.skarabox.sshAuthorizedKey
-  ];
+  openssh.authorizedKeys.keys = config.skarabox.sshAuthorizedKeys;
 };
 ```
 
@@ -356,9 +354,7 @@ the configuration is similar although here the user is `root`:
 
 ```nix
 boot.initrd.network = {
-  ssh.authorizedKeys = [
-    config.skarabox.sshAuthorizedKey
-  ];
+  ssh.authorizedKeys = config.skarabox.sshAuthorizedKeys;
 };
 ```
 

--- a/flakeModules/default.nix
+++ b/flakeModules/default.nix
@@ -21,7 +21,7 @@ let
         skarabox.hostname = "${hostCfg.skarabox.hostname}-beacon";
         skarabox.staticNetwork = hostCfg.skarabox.staticNetwork;
         skarabox.username = hostCfg.skarabox.username;
-        skarabox.sshAuthorizedKey = hostCfg.skarabox.sshAuthorizedKey;
+        skarabox.sshAuthorizedKey = hostCfg.skarabox.sshAuthorizedKeys;
         skarabox.sshPort = hostCfg.skarabox.sshPort;
         skarabox.hotspot.ip = lib.mkIf (hostCfg.skarabox.staticNetwork != null) hostCfg.skarabox.staticNetwork.ip;
         boot.initrd.network.udhcpc.enable = hostCfg.skarabox.staticNetwork == null;

--- a/modules/bootssh.nix
+++ b/modules/bootssh.nix
@@ -29,11 +29,8 @@ in
         # a different port for ssh is used.
         port = lib.mkDefault cfg.sshPort;
         hostKeys = lib.mkForce ([ "/boot/host_key" ] ++ (optionals (config.skarabox.disks.rootPool.disk2 != null) [ "/boot-backup/host_key" ]));
-        # Public ssh key used for login.
-        # This should contain just one line and removing the trailing
-        # newline could be fixed with a removeSuffix call but treating
-        # it as a file containing multiple lines makes this forward compatible.
-        authorizedKeys = config.skarabox.sshAuthorizedKey;
+        # Public SSH keys used for login.
+        authorizedKeys = config.skarabox.sshAuthorizedKeys;
       };
 
       postCommands = ''

--- a/modules/configuration.nix
+++ b/modules/configuration.nix
@@ -41,7 +41,7 @@ in
       isNormalUser = true;
       extraGroups = [ "wheel" ];
       inherit (cfg) hashedPasswordFile;
-      openssh.authorizedKeys.keys = cfg.sshAuthorizedKey;
+      openssh.authorizedKeys.keys = cfg.sshAuthorizedKeys;
     };
 
     security.sudo.extraRules = [

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -13,6 +13,13 @@ let
   readAsListOfStr = v: if lib.isList v then map readAsStr v else [ (readAsStr v) ];
 in
 {
+  imports = [
+    (lib.mkChangedOptionModule
+      [ "skarabox" "sshAuthorizedKey" ]
+      [ "skarabox" "sshAuthorizedKeys" ]
+      (config: readAsListOfStr config.skarabox.sshAuthorizedKey))
+  ];
+
   options.skarabox = {
     hostname = mkOption {
       description = "Hostname to give to the server.";
@@ -62,7 +69,7 @@ in
       '';
     };
 
-    sshAuthorizedKey = mkOption {
+    sshAuthorizedKeys = mkOption {
       type =
         with types;
         let
@@ -77,10 +84,7 @@ in
             keyPath
           ];
         in
-        oneOf [
-          t
-          (listOf t)
-        ];
+        listOf t;
       description = ''
         Public SSH key(s) used to connect on boot to decrypt the root pool.
       '';

--- a/template/myskarabox/configuration.nix
+++ b/template/myskarabox/configuration.nix
@@ -38,7 +38,7 @@ in
       # For security by obscurity, we choose another ssh port here than the default 22.
       skarabox.boot.sshPort = 2223;
       skarabox.sshPort = 2222;
-      skarabox.sshAuthorizedKey = [ ./ssh.pub ];
+      skarabox.sshAuthorizedKeys = [ ./ssh.pub ];
       # If you want to store the ssh key in a ssh agent,
       # set the following option to null.
       # skarabox.sshPrivateKeyPath = null;

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -7,17 +7,18 @@ let
   singleKeyFile = ./fixtures/single-ssh-key.pub;
   singleKey = pkgs.lib.removeSuffix "\n" (builtins.readFile singleKeyFile);
   multiKeyFile = ./fixtures/two-ssh-keys.pub;
-  evalSshAuthorizedKey = sshAuthorizedKey: (pkgs.lib.evalModules {
+  evalSshAuthorizedKey = sshAuthorizedKeys: (pkgs.lib.evalModules {
     modules = [
+      (pkgs.path + "/nixos/modules/misc/assertions.nix")
       ../modules/options.nix
       ({ ... }: {
-        config.skarabox.sshAuthorizedKey = sshAuthorizedKey;
+        config.skarabox.sshAuthorizedKeys = sshAuthorizedKeys;
       })
     ];
-  }).config.skarabox.sshAuthorizedKey;
-  tryEvalSshAuthorizedKey = sshAuthorizedKey:
+  }).config.skarabox.sshAuthorizedKeys;
+  tryEvalSshAuthorizedKey = sshAuthorizedKeys:
     let
-      value = evalSshAuthorizedKey sshAuthorizedKey;
+      value = evalSshAuthorizedKey sshAuthorizedKeys;
     in
     builtins.tryEval (builtins.deepSeq value value);
 
@@ -209,24 +210,34 @@ in
     };
   };
 
-  testSshAuthorizedKeyRejectsMultiLineFile = {
+  testSshAuthorizedKeysRejectsMultiLineFile = {
     expected = false;
-    expr = (tryEvalSshAuthorizedKey multiKeyFile).success;
+    expr = (tryEvalSshAuthorizedKey [ multiKeyFile ]).success;
   };
 
-  testSshAuthorizedKeyRejectsEmptyString = {
+  testSshAuthorizedKeysRejectsEmptyString = {
     expected = false;
-    expr = (tryEvalSshAuthorizedKey "").success;
+    expr = (tryEvalSshAuthorizedKey [ "" ]).success;
   };
 
-  testSshAuthorizedKeyRejectsNewlineTerminatedString = {
+  testSshAuthorizedKeysRejectsNewlineTerminatedString = {
     expected = false;
-    expr = (tryEvalSshAuthorizedKey "${singleKey}\n").success;
+    expr = (tryEvalSshAuthorizedKey [ "${singleKey}\n" ]).success;
   };
 
-  testSshAuthorizedKeyAcceptsNewlineTerminatedFile = {
+  testSshAuthorizedKeysAcceptsNewlineTerminatedFile = {
     expected = [ singleKey ];
-    expr = evalSshAuthorizedKey singleKeyFile;
+    expr = evalSshAuthorizedKey [ singleKeyFile ];
+  };
+
+  testSshAuthorizedKeysRejectsScalarString = {
+    expected = false;
+    expr = (tryEvalSshAuthorizedKey singleKey).success;
+  };
+
+  testSshAuthorizedKeysAcceptsStringList = {
+    expected = [ singleKey ];
+    expr = evalSshAuthorizedKey [ singleKey ];
   };
 
   testMultiHostSameArch = let
@@ -239,17 +250,17 @@ in
           server1 = {
             system = "aarch64-linux";
             hostKeyPub = dummy;
-            sshAuthorizedKey = [ dummy ];
+            sshAuthorizedKeys = [ dummy ];
           };
           server2 = {
             system = "aarch64-linux";
             hostKeyPub = dummy;
-            sshAuthorizedKey = [ dummy ];
+            sshAuthorizedKeys = [ dummy ];
           };
           server3 = {
             system = "x86_64-linux";
             hostKeyPub = dummy;
-            sshAuthorizedKey = [ dummy ];
+            sshAuthorizedKeys = [ dummy ];
           };
         };
       };


### PR DESCRIPTION
Introduce skarabox.sshAuthorizedKeys for target configurations as a list of validated key strings or single-key file paths. Keep the target's former scalar and list forms working through a warning-emitting compatibility conversion, update target consumers, and pass the normalized keys into the unchanged beacon option.