### PR TITLE
Deprecate beacon sshAuthorizedKey option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,11 @@ Template:
 - Deprecated `skarabox.sshAuthorizedKey` in favor of
   `skarabox.sshAuthorizedKeys`, which accepts a list of non-empty, single-line
   SSH public key strings or paths to files containing one such key. This change
-  applies only to target hosts; the beacon's `skarabox.sshAuthorizedKey` option
-  is unchanged.
+  applies only to target hosts.
+
+- Deprecated the beacon module's `skarabox.sshAuthorizedKey` option in favor of
+  `skarabox.sshAuthorizedKeys`. The new option requires a list while preserving
+  the beacon's existing handling of string and path entries.
 
 # v1.6.0
 

--- a/flakeModules/default.nix
+++ b/flakeModules/default.nix
@@ -21,7 +21,7 @@ let
         skarabox.hostname = "${hostCfg.skarabox.hostname}-beacon";
         skarabox.staticNetwork = hostCfg.skarabox.staticNetwork;
         skarabox.username = hostCfg.skarabox.username;
-        skarabox.sshAuthorizedKey = hostCfg.skarabox.sshAuthorizedKeys;
+        skarabox.sshAuthorizedKeys = hostCfg.skarabox.sshAuthorizedKeys;
         skarabox.sshPort = hostCfg.skarabox.sshPort;
         skarabox.hotspot.ip = lib.mkIf (hostCfg.skarabox.staticNetwork != null) hostCfg.skarabox.staticNetwork.ip;
         boot.initrd.network.udhcpc.enable = hostCfg.skarabox.staticNetwork == null;

--- a/modules/beacon.nix
+++ b/modules/beacon.nix
@@ -50,6 +50,10 @@ in {
   imports = [
     ./hotspot.nix
     ./network.nix
+    (lib.mkChangedOptionModule
+      [ "skarabox" "sshAuthorizedKey" ]
+      [ "skarabox" "sshAuthorizedKeys" ]
+      (config: readAsListOfStr config.skarabox.sshAuthorizedKey))
   ];
 
   options.skarabox = {
@@ -97,7 +101,7 @@ in {
       defaultText = "config.skarabox.sshPort";
     };
 
-    sshAuthorizedKey = lib.mkOption {
+    sshAuthorizedKeys = lib.mkOption {
       type =
         with types;
         let
@@ -106,10 +110,7 @@ in {
             path
           ];
         in
-        oneOf [
-          t
-          (listOf t)
-        ];
+        listOf t;
       description = ''
         Public key(s) to connect to the beacon.
 
@@ -122,8 +123,8 @@ in {
 
         If installing on a cloud instance, set this to the ssh key that can ssh into the instance as given by your cloud provider.
       '';
-      default = cfg.sshAuthorizedKey;
-      defaultText = "config.skarabox.sshAuthorizedKey";
+      default = cfg.sshAuthorizedKeys;
+      defaultText = "config.skarabox.sshAuthorizedKeys";
       apply = readAsListOfStr;
     };
   };
@@ -133,7 +134,7 @@ in {
 
     # Also allow root to connect for nixos-anywhere.
     users.users.root = {
-      openssh.authorizedKeys.keys = cfg.sshAuthorizedKey;
+      openssh.authorizedKeys.keys = cfg.sshAuthorizedKeys;
     };
     # Override user set in profiles/installation-device.nix
     users.users.${cfg.username} = {
@@ -142,7 +143,7 @@ in {
       # Allow the graphical user to login without password
       initialHashedPassword = "";
       # Set shared ssh key
-      openssh.authorizedKeys.keys = cfg.sshAuthorizedKey;
+      openssh.authorizedKeys.keys = cfg.sshAuthorizedKeys;
     };
     # Automatically log in at the virtual consoles.
     services.getty.autologinUser = lib.mkForce cfg.username;


### PR DESCRIPTION
Introduce skarabox.sshAuthorizedKeys for beacon configurations as a list of string or path entries. Keep the former scalar and list forms working through a warning-emitting compatibility conversion, and update the target-to-beacon bridge and beacon consumers.