### PR TITLE
Configure nixfmt-tree

### DIFF
--- a/.github/workflows/format.yaml
+++ b/.github/workflows/format.yaml
@@ -1,0 +1,24 @@
+name: "format"
+on:
+  pull_request:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Install Nix
+        uses: cachix/install-nix-action@v31
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Setup Caching
+        uses: cachix/cachix-action@v17
+        with:
+          name: selfhostblocks
+          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+      - name: Check Formatting
+        run: |
+          find . -name '*.nix' | nix fmt -- --ci

--- a/docs/default.nix
+++ b/docs/default.nix
@@ -1,36 +1,41 @@
 # Taken nearly verbatim from https://github.com/nix-community/home-manager/pull/4673
 # Read these docs online at https://shb.skarabox.com.
-{ pkgs
-, buildPackages
-, lib
-, nmdsrc
-, stdenv
-, documentation-highlighter
-, nixos-render-docs
+{
+  pkgs,
+  buildPackages,
+  lib,
+  nmdsrc,
+  stdenv,
+  documentation-highlighter,
+  nixos-render-docs,
 
-, release
-, skaraboxModules
-, flakeModuleModules
+  release,
+  skaraboxModules,
+  flakeModuleModules,
 }:
 
 let
   shbPath = toString ./..;
 
-  gitHubDeclaration = user: repo: subpath:
-    let urlRef = "main";
-        end = if subpath == "" then "" else "/" + subpath;
-    in {
+  gitHubDeclaration =
+    user: repo: subpath:
+    let
+      urlRef = "main";
+      end = if subpath == "" then "" else "/" + subpath;
+    in
+    {
       url = "https://github.com/${user}/${repo}/blob/${urlRef}${end}";
       name = "<${repo}${end}>";
     };
 
   ghRoot = (gitHubDeclaration "ibizaman" "skarabox" "").url;
 
-  buildOptionsDocs = args@{ modules, ... }:
+  buildOptionsDocs =
+    args@{ modules, ... }:
     let
       config = {
         _module.check = false;
-        _module.args = {};
+        _module.args = { };
         system.stateVersion = "22.11";
       };
 
@@ -48,28 +53,42 @@ let
       };
 
       options = lib.filterAttrs (name: v: name == "skarabox") eval.options;
-    in buildPackages.nixosOptionsDoc ({
-      inherit options;
+    in
+    buildPackages.nixosOptionsDoc (
+      {
+        inherit options;
 
-      transformOptions = opt:
-        opt // {
-          # Clean up declaration sites to not refer to the Home Manager
-          # source tree.
-          declarations = map (decl:
-            gitHubDeclaration "ibizaman" "skarabox"
-              (lib.removePrefix "/" (lib.removePrefix shbPath (toString decl)))) opt.declarations;
-        };
-    } // builtins.removeAttrs args [ "modules" "includeModuleSystemOptions" ]);
+        transformOptions =
+          opt:
+          opt
+          // {
+            # Clean up declaration sites to not refer to the Home Manager
+            # source tree.
+            declarations = map (
+              decl:
+              gitHubDeclaration "ibizaman" "skarabox" (
+                lib.removePrefix "/" (lib.removePrefix shbPath (toString decl))
+              )
+            ) opt.declarations;
+          };
+      }
+      // builtins.removeAttrs args [
+        "modules"
+        "includeModuleSystemOptions"
+      ]
+    );
 
   scrubbedModule = {
     _module.args.pkgs = lib.mkForce (nmd.scrubDerivations "pkgs" pkgs);
     _module.check = false;
   };
 
-  mkOptionsDocs = modules: (buildOptionsDocs {
-    modules = modules ++ [ scrubbedModule ];
-    variablelistId = "skarabox-options";
-  }).optionsJSON;
+  mkOptionsDocs =
+    modules:
+    (buildOptionsDocs {
+      modules = modules ++ [ scrubbedModule ];
+      variablelistId = "skarabox-options";
+    }).optionsJSON;
 
   nmd = import nmdsrc {
     inherit lib;
@@ -77,15 +96,15 @@ let
     # `nmd` uses to work around the broken stylesheets in
     # `docbook-xsl-ns`, so we restore the patched version here.
     pkgs = pkgs // {
-      docbook-xsl-ns =
-        pkgs.docbook-xsl-ns.override { withManOptDedupPatch = true; };
+      docbook-xsl-ns = pkgs.docbook-xsl-ns.override { withManOptDedupPatch = true; };
     };
   };
 
   outputPath = "share/doc/skarabox";
 
-  manpage-urls = pkgs.writeText "manpage-urls.json" ''{}'';
-in stdenv.mkDerivation {
+  manpage-urls = pkgs.writeText "manpage-urls.json" "{}";
+in
+stdenv.mkDerivation {
   name = "skarabox-manual";
 
   nativeBuildInputs = [ nixos-render-docs ];

--- a/flake.nix
+++ b/flake.nix
@@ -25,141 +25,166 @@
     };
   };
 
-  outputs = inputs@{
-    self,
-    flake-parts,
-    nixos-anywhere,
-    nix-flake-tests,
-    ...
-  }: let
-    skaraboxLib = import ./lib/functions.nix { inherit (inputs) nixpkgs; };
-  in flake-parts.lib.mkFlake {
-    inherit inputs;
-    specialArgs = { inherit skaraboxLib; };
-  } {
-    systems = [
-      "x86_64-linux"
-      "aarch64-linux"
-      # Darwin systems are supported but not as hosts to deploy to.
-      "aarch64-darwin"
-    ];
-
-    perSystem = { self', inputs', pkgs, system, ... }: {
-      packages = rec {
-        # Usage:
-        #  init [-h] [-y] [-s] [-v]
-        #
-        # printasdf help:
-        #  init -h
-        init = import ./lib/gen-initial.nix {
-          inherit pkgs gen-new-host sops-create-main-key sops-add-main-key;
-        };
-
-        add-sops-cfg = import ./lib/add-sops-cfg.nix {
-          inherit pkgs;
-        };
-
-        sops-create-main-key = import ./lib/sops-create-main-key.nix {
-          inherit pkgs;
-        };
-
-        sops-add-main-key = import ./lib/sops-add-main-key.nix {
-          inherit pkgs add-sops-cfg;
-        };
-
-        gen-new-host = import ./lib/gen-new-host.nix {
-          inherit add-sops-cfg pkgs gen-hostId gen-machineId;
-          inherit (pkgs) lib;
-        };
-
-        gen-hostId = pkgs.writeShellApplication {
-          name = "gen-hostId";
-
-          runtimeInputs = [
-            pkgs.util-linux
-          ];
-
-          text = ''
-            uuidgen | head -c 8
-          '';
-        };
-
-        gen-machineId = pkgs.writeShellApplication {
-          name = "gen-machineId";
-
-          runtimeInputs = [
-            pkgs.util-linux
-          ];
-
-          text = ''
-            uuidgen -r | tr -d -
-          '';
-        };
-
-        manualHtml = pkgs.callPackage ./docs {
-          inherit (inputs) nmdsrc;
-          skaraboxModules = [
-            ./modules/bootssh.nix
-            ./modules/configuration.nix
-            ./modules/disks.nix
-            ./modules/hotspot.nix
-          ];
-          flakeModuleModules = [
-            ./flakeModules/default.nix
-            ./flakeModules/colmena.nix
-            ./flakeModules/deploy-rs.nix
-          ];
-          release = builtins.readFile ./VERSION;
-        };
-      };
-
-      checks = import ./tests {
-        inherit pkgs system nix-flake-tests;
-      };
-
-      # Used to experiment with ruamel library.
-      devShells.pythonShell = pkgs.mkShell {
-        packages = [
-          (pkgs.python3.withPackages (python-pkgs: [
-            python-pkgs.ruamel-yaml
-          ]))
+  outputs =
+    inputs@{
+      self,
+      flake-parts,
+      nixos-anywhere,
+      nix-flake-tests,
+      ...
+    }:
+    let
+      skaraboxLib = import ./lib/functions.nix { inherit (inputs) nixpkgs; };
+    in
+    flake-parts.lib.mkFlake
+      {
+        inherit inputs;
+        specialArgs = { inherit skaraboxLib; };
+      }
+      {
+        systems = [
+          "x86_64-linux"
+          "aarch64-linux"
+          # Darwin systems are supported but not as hosts to deploy to.
+          "aarch64-darwin"
         ];
-      };
-    };
 
-    flake = {
-      lib = skaraboxLib;
+        perSystem =
+          {
+            self',
+            inputs',
+            pkgs,
+            system,
+            ...
+          }:
+          {
+            formatter = pkgs.nixfmt-tree;
 
-      skaraboxInputs = inputs;
+            packages = rec {
+              # Usage:
+              #  init [-h] [-y] [-s] [-v]
+              #
+              # printasdf help:
+              #  init -h
+              init = import ./lib/gen-initial.nix {
+                inherit
+                  pkgs
+                  gen-new-host
+                  sops-create-main-key
+                  sops-add-main-key
+                  ;
+              };
 
-      flakeModules.default = ./flakeModules/default.nix;
-      flakeModules.colmena = ./flakeModules/colmena.nix;
-      flakeModules.deploy-rs = ./flakeModules/deploy-rs.nix;
+              add-sops-cfg = import ./lib/add-sops-cfg.nix {
+                inherit pkgs;
+              };
 
-      templates = {
-        skarabox = {
-          path = ./template;
-          description = "Skarabox template";
+              sops-create-main-key = import ./lib/sops-create-main-key.nix {
+                inherit pkgs;
+              };
+
+              sops-add-main-key = import ./lib/sops-add-main-key.nix {
+                inherit pkgs add-sops-cfg;
+              };
+
+              gen-new-host = import ./lib/gen-new-host.nix {
+                inherit
+                  add-sops-cfg
+                  pkgs
+                  gen-hostId
+                  gen-machineId
+                  ;
+                inherit (pkgs) lib;
+              };
+
+              gen-hostId = pkgs.writeShellApplication {
+                name = "gen-hostId";
+
+                runtimeInputs = [
+                  pkgs.util-linux
+                ];
+
+                text = ''
+                  uuidgen | head -c 8
+                '';
+              };
+
+              gen-machineId = pkgs.writeShellApplication {
+                name = "gen-machineId";
+
+                runtimeInputs = [
+                  pkgs.util-linux
+                ];
+
+                text = ''
+                  uuidgen -r | tr -d -
+                '';
+              };
+
+              manualHtml = pkgs.callPackage ./docs {
+                inherit (inputs) nmdsrc;
+                skaraboxModules = [
+                  ./modules/bootssh.nix
+                  ./modules/configuration.nix
+                  ./modules/disks.nix
+                  ./modules/hotspot.nix
+                ];
+                flakeModuleModules = [
+                  ./flakeModules/default.nix
+                  ./flakeModules/colmena.nix
+                  ./flakeModules/deploy-rs.nix
+                ];
+                release = builtins.readFile ./VERSION;
+              };
+            };
+
+            checks = import ./tests {
+              inherit pkgs system nix-flake-tests;
+            };
+
+            # Used to experiment with ruamel library.
+            devShells.pythonShell = pkgs.mkShell {
+              packages = [
+                (pkgs.python3.withPackages (python-pkgs: [
+                  python-pkgs.ruamel-yaml
+                ]))
+              ];
+            };
+          };
+
+        flake = {
+          lib = skaraboxLib;
+
+          skaraboxInputs = inputs;
+
+          flakeModules.default = ./flakeModules/default.nix;
+          flakeModules.colmena = ./flakeModules/colmena.nix;
+          flakeModules.deploy-rs = ./flakeModules/deploy-rs.nix;
+
+          templates = {
+            skarabox = {
+              path = ./template;
+              description = "Skarabox template";
+            };
+
+            default = self.templates.skarabox;
+          };
+
+          nixosModules.skarabox = {
+            imports = [
+              nixos-anywhere.inputs.disko.nixosModules.disko
+              ./modules/disks.nix
+              ./modules/bootssh.nix
+              ./modules/configuration.nix
+            ];
+          };
+
+          nix-ci = {
+            cachix = {
+              name = "selfhostblocks";
+              public-key = "selfhostblocks.cachix.org-1:H5h6Uj188DObUJDbEbSAwc377uvcjSFOfpxyCFP7cVs=";
+            };
+          };
         };
-
-        default = self.templates.skarabox;
       };
-
-      nixosModules.skarabox = {
-        imports = [
-          nixos-anywhere.inputs.disko.nixosModules.disko
-          ./modules/disks.nix
-          ./modules/bootssh.nix
-          ./modules/configuration.nix
-        ];
-      };
-
-      nix-ci = {
-        cachix = {
-          name = "selfhostblocks";
-          public-key = "selfhostblocks.cachix.org-1:H5h6Uj188DObUJDbEbSAwc377uvcjSFOfpxyCFP7cVs=";
-        };
-      };
-    };
-  };
 }

--- a/flakeModules/colmena.nix
+++ b/flakeModules/colmena.nix
@@ -12,42 +12,62 @@ let
 in
 {
   config = {
-    perSystem = { inputs', ... }: {
-      apps = {
-        inherit (inputs'.colmena.apps) colmena;
+    perSystem =
+      { inputs', ... }:
+      {
+        apps = {
+          inherit (inputs'.colmena.apps) colmena;
+        };
       };
-    };
 
-    flake = flakeInputs: let
-      mkFlake = name: cfg': {
-        colmenaHive = inputs.colmena.lib.makeHive ({
-          meta.nixpkgs = import inputs.nixpkgs { system = "x86_64-linux"; };
-          meta.nodeNixpkgs = mapAttrs (_: cfg': import (if cfg'.nixpkgs != null then cfg'.nixpkgs else inputs.nixpkgs)  { inherit (cfg') system; }) cfg.hosts;
-        } // (let
-          mkNode = name: cfg': let
-            hostCfg = topLevelConfig.flake.nixosConfigurations.${name}.config;
-          in
+    flake =
+      flakeInputs:
+      let
+        mkFlake = name: cfg': {
+          colmenaHive = inputs.colmena.lib.makeHive (
             {
-              deployment = {
-                targetHost = cfg'.ip;
-                targetPort = hostCfg.skarabox.sshPort;
-                targetUser = topLevelConfig.flake.nixosConfigurations.${name}.config.skarabox.username;
-                sshOptions = [
-                  "-o" "IdentitiesOnly=yes"
-                  "-o" "UserKnownHostsFile=${cfg'.knownHostsPath}"
-                  "-o" "ConnectTimeout=10"
-                ] ++ lib.optionals (cfg'.sshPrivateKeyPath != null) [ "-i" cfg'.sshPrivateKeyPath ];
-              };
+              meta.nixpkgs = import inputs.nixpkgs { system = "x86_64-linux"; };
+              meta.nodeNixpkgs = mapAttrs (
+                _: cfg':
+                import (if cfg'.nixpkgs != null then cfg'.nixpkgs else inputs.nixpkgs) { inherit (cfg') system; }
+              ) cfg.hosts;
+            }
+            // (
+              let
+                mkNode =
+                  name: cfg':
+                  let
+                    hostCfg = topLevelConfig.flake.nixosConfigurations.${name}.config;
+                  in
+                  {
+                    deployment = {
+                      targetHost = cfg'.ip;
+                      targetPort = hostCfg.skarabox.sshPort;
+                      targetUser = topLevelConfig.flake.nixosConfigurations.${name}.config.skarabox.username;
+                      sshOptions = [
+                        "-o"
+                        "IdentitiesOnly=yes"
+                        "-o"
+                        "UserKnownHostsFile=${cfg'.knownHostsPath}"
+                        "-o"
+                        "ConnectTimeout=10"
+                      ]
+                      ++ lib.optionals (cfg'.sshPrivateKeyPath != null) [
+                        "-i"
+                        cfg'.sshPrivateKeyPath
+                      ];
+                    };
 
-              imports = cfg'.modules ++ [
-                inputs.skarabox.nixosModules.skarabox
-              ];
-            };
-        in
-          mapAttrs mkNode cfg.hosts
-        ));
-      };
-    in
+                    imports = cfg'.modules ++ [
+                      inputs.skarabox.nixosModules.skarabox
+                    ];
+                  };
+              in
+              mapAttrs mkNode cfg.hosts
+            )
+          );
+        };
+      in
       (concatMapAttrs mkFlake cfg.hosts);
   };
 }

--- a/flakeModules/default.nix
+++ b/flakeModules/default.nix
@@ -8,25 +8,42 @@ let
   topLevelConfig = config;
   cfg = config.skarabox;
 
-  inherit (lib) concatMapAttrs concatStringsSep mapAttrsToList mkOption optionalAttrs types;
+  inherit (lib)
+    concatMapAttrs
+    concatStringsSep
+    mapAttrsToList
+    mkOption
+    optionalAttrs
+    types
+    ;
 
   readAndTrim = f: lib.strings.trim (builtins.readFile f);
   readAsStr = v: if lib.isPath v then readAndTrim v else v;
 
-  beacon-module = hostCfg: { config, lib, modulesPath, ... }: {
-    imports = [
-      ../modules/beacon.nix
-      (modulesPath + "/profiles/minimal.nix")
-      {
-        skarabox.hostname = "${hostCfg.skarabox.hostname}-beacon";
-        skarabox.staticNetwork = hostCfg.skarabox.staticNetwork;
-        skarabox.username = hostCfg.skarabox.username;
-        skarabox.sshAuthorizedKeys = hostCfg.skarabox.sshAuthorizedKeys;
-        skarabox.sshPort = hostCfg.skarabox.sshPort;
-        skarabox.hotspot.ip = lib.mkIf (hostCfg.skarabox.staticNetwork != null) hostCfg.skarabox.staticNetwork.ip;
-      }
-    ];
-  };
+  beacon-module =
+    hostCfg:
+    {
+      config,
+      lib,
+      modulesPath,
+      ...
+    }:
+    {
+      imports = [
+        ../modules/beacon.nix
+        (modulesPath + "/profiles/minimal.nix")
+        {
+          skarabox.hostname = "${hostCfg.skarabox.hostname}-beacon";
+          skarabox.staticNetwork = hostCfg.skarabox.staticNetwork;
+          skarabox.username = hostCfg.skarabox.username;
+          skarabox.sshAuthorizedKeys = hostCfg.skarabox.sshAuthorizedKeys;
+          skarabox.sshPort = hostCfg.skarabox.sshPort;
+          skarabox.hotspot.ip = lib.mkIf (
+            hostCfg.skarabox.staticNetwork != null
+          ) hostCfg.skarabox.staticNetwork.ip;
+        }
+      ];
+    };
 
   skaraboxLib = import ../lib/functions.nix { inherit (inputs) nixpkgs; };
 in
@@ -41,615 +58,711 @@ in
 
     hosts = mkOption {
       description = "Hosts managed by Skarabox.";
-      default = {};
-      type = types.attrsOf (types.submodule ({ name, config, ... }: {
-        options = let
-          hostCfg = topLevelConfig.flake.nixosConfigurations.${name}.config;
-        in {
-          nixpkgs = mkOption {
-            # No evaluation or merging is wanted here, thus the raw type.
-            type = types.raw;
-            defaultText = "inputs.nixpkgs";
-            default = null;
-            description = ''
-              If given, overrides nixpkgs in the nixosConfiguration, including `nixos/modules/`.
-
-              By default, uses the nixpkgs input.
-
-              This option allows to patch nixpkgs following https://wiki.nixos.org/wiki/Nixpkgs/Patching_Nixpkgs
-            '';
-          };
-          specialArgs = mkOption {
-            description = "Extra specialArgs passed to the host nixosConfiguration.";
-            type = types.attrsOf types.raw;
-            default = { };
-          };
-          hostKeyPath = mkOption {
-            description = "Path from the top of the repo to the ssh private file used as the host key.";
-            type = types.str;
-            default = "${name}/host_key";
-          };
-          hostKeyPub = mkOption {
-            description = "SSH public file used as the host key.";
-            type = with types; oneOf [ str path ];
-            apply = readAsStr;
-            example = lib.literalExpression "./${name}/host_key.pub";
-          };
-          ip = mkOption {
-            description = ''
-              IP or hostname used to ssh into the server.
-
-              This can be the fqdn used to access the server
-              or the external IP if port forwarding is configured on the router
-              or the internal IP if on the same network.
-
-              All cases are valid and might need to be adapted if the server moves
-              or if the DNS or DHCP server are mis-configured.
-            '';
-            type = types.str;
-            default = "127.0.0.1";
-          };
-          sshPort = mkOption {
-            description = ''
-              Port used to ssh into the server.
-
-              By default it is the same as the port configured in the NixOS module in configuration.nix
-              but can be different if accessing the server from outside with some port forwarding enabled
-              or if you want to update the ssh port.
-
-              To update the ssh port of a live target host, first update the ssh port in the configuration.nix
-              then deploy the new change, and finally update the port here.
-            '';
-            type = types.port;
-            default = hostCfg.skarabox.sshPort;
-            defaultText = "topLevelConfig.flake.nixosConfigurations.${name}.config.skarabox.sshPort";
-          };
-          sshBootPort = mkOption {
-            description = ''
-              Port used to ssh into the server.
-
-              By default it is the same as the port configured in the NixOS module in configuration.nix
-              but can be different if accessing the server from outside with some port forwarding enabled
-              or if you want to update the ssh port.
-
-              To update the ssh port of a live target host, first update the ssh port in the configuration.nix
-              then deploy the new change, and finally update the port here.
-            '';
-            type = types.port;
-            default = hostCfg.skarabox.boot.sshPort;
-            defaultText = "topLevelConfig.flake.nixosConfigurations.${name}.config.skarabox.boot.sshPort";
-          };
-          sshPrivateKeyPath = mkOption {
-            description = "Path from the top of the repo to the ssh private file used to ssh into the host. Set to null if you use an ssh agent.";
-            type = types.nullOr types.str;
-            default = "${name}/ssh";
-          };
-          sshPublicKeyPath = lib.mkOption {
-            description = ''
-              Path from the top of the repo to the ssh public file used to ssh into the host.
-
-              Should be only necessary when using an ssh agent which has a lot of ssh keys.
-              Setting this option allows the ssh agent to know which key to give,
-              otherwise ssh might fail with "too many authentication attempts".
-
-              If set, you should probably set sshPrivateKeyPath to null.
-            '';
-            type = types.nullOr types.str;
-            default = null;
-          };
-          secretsFilePath = mkOption {
-            description = ''
-              Path from the top of the repo to the SOPS secrets file.
-
-              By default Skarabox assumes one secret file per host to avoid
-              sharing secrets across them but having only one file by specifying
-              "./secrets.yaml" is possible too.
-            '';
-            type = types.str;
-            default = "${name}/secrets.yaml";
-          };
-          secretsRootPassphrasePath = mkOption {
-            description = "Path in python dictionary format to the passphrase of the root ZFS pool as it is stored in the SOPS secrets file.";
-            type = types.str;
-            default = "['${name}']['disks']['rootPassphrase']";
-          };
-          secretsDataPassphrasePath = mkOption {
-            description = "Path in python dictionary format to the passphrase of the data ZFS pool as it is stored in the SOPS secrets file.";
-            type = types.str;
-            default = "['${name}']['disks']['dataPassphrase']";
-          };
-          extraSecretsPassphrasesPath = mkOption {
-            description = "Paths in python dictionary format to other passphrases for extra ZFS pools as they is stored in the SOPS secrets file.";
-            type = with types; attrsOf str;
-            default = {};
-            example = lib.literalExpression ''
+      default = { };
+      type = types.attrsOf (
+        types.submodule (
+          { name, config, ... }:
+          {
+            options =
+              let
+                hostCfg = topLevelConfig.flake.nixosConfigurations.${name}.config;
+              in
               {
-                backup_passphrase = "['${name}']['disks']['backupPassphrase']";
-              }
-            '';
-          };
-          knownHostsPath = mkOption {
-            description = "Path from the top of the repo to known hosts file.";
-            type = types.str;
-            default = "${name}/known_hosts";
-          };
-          system = mkOption {
-            description = ''
-              System of the host.
+                nixpkgs = mkOption {
+                  # No evaluation or merging is wanted here, thus the raw type.
+                  type = types.raw;
+                  defaultText = "inputs.nixpkgs";
+                  default = null;
+                  description = ''
+                    If given, overrides nixpkgs in the nixosConfiguration, including `nixos/modules/`.
 
-              Can be the systm directly or a file containing the value.
-            '';
-            type = with types; oneOf [ str path ];
-            apply = readAsStr;
-          };
+                    By default, uses the nixpkgs input.
 
-          beacon = {
-            username = lib.mkOption {
-              description = ''
-                Username with which you can log into the beacon.
+                    This option allows to patch nixpkgs following https://wiki.nixos.org/wiki/Nixpkgs/Patching_Nixpkgs
+                  '';
+                };
+                specialArgs = mkOption {
+                  description = "Extra specialArgs passed to the host nixosConfiguration.";
+                  type = types.attrsOf types.raw;
+                  default = { };
+                };
+                hostKeyPath = mkOption {
+                  description = "Path from the top of the repo to the ssh private file used as the host key.";
+                  type = types.str;
+                  default = "${name}/host_key";
+                };
+                hostKeyPub = mkOption {
+                  description = "SSH public file used as the host key.";
+                  type =
+                    with types;
+                    oneOf [
+                      str
+                      path
+                    ];
+                  apply = readAsStr;
+                  example = lib.literalExpression "./${name}/host_key.pub";
+                };
+                ip = mkOption {
+                  description = ''
+                    IP or hostname used to ssh into the server.
 
-                Defaults to the username configured for the target host, which should work in most cases.
+                    This can be the fqdn used to access the server
+                    or the external IP if port forwarding is configured on the router
+                    or the internal IP if on the same network.
 
-                If installing on a cloud instance, set this to the user that can ssh into the instance as given by your cloud provider.
-              '';
-              type = types.str;
-              default = hostCfg.skarabox.username;
-              defaultText = "topLevelConfig.flake.nixosConfigurations.${name}.config.skarabox.username";
-            };
+                    All cases are valid and might need to be adapted if the server moves
+                    or if the DNS or DHCP server are mis-configured.
+                  '';
+                  type = types.str;
+                  default = "127.0.0.1";
+                };
+                sshPort = mkOption {
+                  description = ''
+                    Port used to ssh into the server.
 
-            sshPort = lib.mkOption {
-              type = types.int;
-              description = ''
-                Port the SSH daemon listens to on the beacon.
+                    By default it is the same as the port configured in the NixOS module in configuration.nix
+                    but can be different if accessing the server from outside with some port forwarding enabled
+                    or if you want to update the ssh port.
 
-                Defaults to the same port configured for the target host, which should work in most cases.
+                    To update the ssh port of a live target host, first update the ssh port in the configuration.nix
+                    then deploy the new change, and finally update the port here.
+                  '';
+                  type = types.port;
+                  default = hostCfg.skarabox.sshPort;
+                  defaultText = "topLevelConfig.flake.nixosConfigurations.${name}.config.skarabox.sshPort";
+                };
+                sshBootPort = mkOption {
+                  description = ''
+                    Port used to ssh into the server.
 
-                If installing on a cloud instance, set this to the port that can ssh into the instance as given by your cloud provider, usually 22.
-              '';
-              default = config.sshPort;
-              defaultText = "config.skarabox.sshPort";
-            };
+                    By default it is the same as the port configured in the NixOS module in configuration.nix
+                    but can be different if accessing the server from outside with some port forwarding enabled
+                    or if you want to update the ssh port.
 
-            sshPrivateKeyPath = lib.mkOption {
-              description = ''
-                Path from the top of the repo to the ssh private file used to ssh into the host.
+                    To update the ssh port of a live target host, first update the ssh port in the configuration.nix
+                    then deploy the new change, and finally update the port here.
+                  '';
+                  type = types.port;
+                  default = hostCfg.skarabox.boot.sshPort;
+                  defaultText = "topLevelConfig.flake.nixosConfigurations.${name}.config.skarabox.boot.sshPort";
+                };
+                sshPrivateKeyPath = mkOption {
+                  description = "Path from the top of the repo to the ssh private file used to ssh into the host. Set to null if you use an ssh agent.";
+                  type = types.nullOr types.str;
+                  default = "${name}/ssh";
+                };
+                sshPublicKeyPath = lib.mkOption {
+                  description = ''
+                    Path from the top of the repo to the ssh public file used to ssh into the host.
 
-                Defaults to the ssh key for the target host `skarabox.hosts.<name>.sshPublicKeyPath`.
+                    Should be only necessary when using an ssh agent which has a lot of ssh keys.
+                    Setting this option allows the ssh agent to know which key to give,
+                    otherwise ssh might fail with "too many authentication attempts".
 
-                Set to null if you use an ssh agent. See also sshPublicKeyPath.
-              '';
-              type = types.nullOr types.str;
-              default = config.sshPrivateKeyPath;
-            };
-            sshPublicKeyPath = lib.mkOption {
-              description = ''
-                Path from the top of the repo to the ssh public file used to ssh into the host.
+                    If set, you should probably set sshPrivateKeyPath to null.
+                  '';
+                  type = types.nullOr types.str;
+                  default = null;
+                };
+                secretsFilePath = mkOption {
+                  description = ''
+                    Path from the top of the repo to the SOPS secrets file.
 
-                Defaults to the ssh key for the target host `skarabox.hosts.<name>.sshPublicKeyPath`.
+                    By default Skarabox assumes one secret file per host to avoid
+                    sharing secrets across them but having only one file by specifying
+                    "./secrets.yaml" is possible too.
+                  '';
+                  type = types.str;
+                  default = "${name}/secrets.yaml";
+                };
+                secretsRootPassphrasePath = mkOption {
+                  description = "Path in python dictionary format to the passphrase of the root ZFS pool as it is stored in the SOPS secrets file.";
+                  type = types.str;
+                  default = "['${name}']['disks']['rootPassphrase']";
+                };
+                secretsDataPassphrasePath = mkOption {
+                  description = "Path in python dictionary format to the passphrase of the data ZFS pool as it is stored in the SOPS secrets file.";
+                  type = types.str;
+                  default = "['${name}']['disks']['dataPassphrase']";
+                };
+                extraSecretsPassphrasesPath = mkOption {
+                  description = "Paths in python dictionary format to other passphrases for extra ZFS pools as they is stored in the SOPS secrets file.";
+                  type = with types; attrsOf str;
+                  default = { };
+                  example = lib.literalExpression ''
+                    {
+                      backup_passphrase = "['${name}']['disks']['backupPassphrase']";
+                    }
+                  '';
+                };
+                knownHostsPath = mkOption {
+                  description = "Path from the top of the repo to known hosts file.";
+                  type = types.str;
+                  default = "${name}/known_hosts";
+                };
+                system = mkOption {
+                  description = ''
+                    System of the host.
 
-                Should be only necessary when using an ssh agent which has a lot of ssh keys.
-                Setting this option allows the ssh agent to know which key to give,
-                otherwise ssh might fail with "too many authentication attempts".
+                    Can be the systm directly or a file containing the value.
+                  '';
+                  type =
+                    with types;
+                    oneOf [
+                      str
+                      path
+                    ];
+                  apply = readAsStr;
+                };
 
-                If set, you should probably set sshPrivateKeyPath to null.
-              '';
-              type = types.nullOr types.str;
-              default = config.sshPublicKeyPath;
-            };
-          };
+                beacon = {
+                  username = lib.mkOption {
+                    description = ''
+                      Username with which you can log into the beacon.
 
-          modules = mkOption {
-            description = "Modules to add to the host nixosConfiguration. Add here all your own configuration.";
-            type = types.listOf types.anything;
-            default = [];
-          };
-          extraBeaconModules = mkOption {
-            description = "Modules to add to the beacon configuration. Use this to add static network config, for example.";
-            type = types.listOf types.anything;
-            default = [];
-            example = ''
-              extraBeaconModules = [
-                {
-                  environment.systemPackages = [ pkgs.tmux ];
-                }
-              ];
-            '';
-          };
-        };
-      }));
+                      Defaults to the username configured for the target host, which should work in most cases.
+
+                      If installing on a cloud instance, set this to the user that can ssh into the instance as given by your cloud provider.
+                    '';
+                    type = types.str;
+                    default = hostCfg.skarabox.username;
+                    defaultText = "topLevelConfig.flake.nixosConfigurations.${name}.config.skarabox.username";
+                  };
+
+                  sshPort = lib.mkOption {
+                    type = types.int;
+                    description = ''
+                      Port the SSH daemon listens to on the beacon.
+
+                      Defaults to the same port configured for the target host, which should work in most cases.
+
+                      If installing on a cloud instance, set this to the port that can ssh into the instance as given by your cloud provider, usually 22.
+                    '';
+                    default = config.sshPort;
+                    defaultText = "config.skarabox.sshPort";
+                  };
+
+                  sshPrivateKeyPath = lib.mkOption {
+                    description = ''
+                      Path from the top of the repo to the ssh private file used to ssh into the host.
+
+                      Defaults to the ssh key for the target host `skarabox.hosts.<name>.sshPublicKeyPath`.
+
+                      Set to null if you use an ssh agent. See also sshPublicKeyPath.
+                    '';
+                    type = types.nullOr types.str;
+                    default = config.sshPrivateKeyPath;
+                  };
+                  sshPublicKeyPath = lib.mkOption {
+                    description = ''
+                      Path from the top of the repo to the ssh public file used to ssh into the host.
+
+                      Defaults to the ssh key for the target host `skarabox.hosts.<name>.sshPublicKeyPath`.
+
+                      Should be only necessary when using an ssh agent which has a lot of ssh keys.
+                      Setting this option allows the ssh agent to know which key to give,
+                      otherwise ssh might fail with "too many authentication attempts".
+
+                      If set, you should probably set sshPrivateKeyPath to null.
+                    '';
+                    type = types.nullOr types.str;
+                    default = config.sshPublicKeyPath;
+                  };
+                };
+
+                modules = mkOption {
+                  description = "Modules to add to the host nixosConfiguration. Add here all your own configuration.";
+                  type = types.listOf types.anything;
+                  default = [ ];
+                };
+                extraBeaconModules = mkOption {
+                  description = "Modules to add to the beacon configuration. Use this to add static network config, for example.";
+                  type = types.listOf types.anything;
+                  default = [ ];
+                  example = ''
+                    extraBeaconModules = [
+                      {
+                        environment.systemPackages = [ pkgs.tmux ];
+                      }
+                    ];
+                  '';
+                };
+              };
+          }
+        )
+      );
     };
   };
 
   config = {
-    perSystem = { self', inputs', config, pkgs, system, ... }: let
-      sops = pkgs.writeShellApplication {
-        name = "sops";
-
-        runtimeInputs = [
-          pkgs.sops
-        ];
-
-        text = ''
-          SOPS_AGE_KEY_FILE=${cfg.sopsKeyPath} sops "$@"
-        '';
-      };
-
-      mkHostPackages = name: cfg': let
-        hostCfg = topLevelConfig.flake.nixosConfigurations.${name}.config;
-
-        # nix run .#boot-ssh
-        boot-ssh = pkgs.writeShellApplication {
-          name = "boot-ssh";
+    perSystem =
+      {
+        self',
+        inputs',
+        config,
+        pkgs,
+        system,
+        ...
+      }:
+      let
+        sops = pkgs.writeShellApplication {
+          name = "sops";
 
           runtimeInputs = [
-            (import ../lib/ssh.nix {
-              inherit pkgs;
-            })
+            pkgs.sops
           ];
 
           text = ''
-            ssh \
-              "${cfg'.ip}" \
-              "${toString cfg'.sshBootPort}" \
-              root \
-              -o UserKnownHostsFile=${cfg'.knownHostsPath} \
-              -o ConnectTimeout=10 \
-              ${if cfg'.sshPrivateKeyPath != null then "-i ${cfg'.sshPrivateKeyPath}" else ""} \
-              ${if cfg'.sshPublicKeyPath != null then "-i ${cfg'.sshPublicKeyPath}" else ""} \
-              "$*"
+            SOPS_AGE_KEY_FILE=${cfg.sopsKeyPath} sops "$@"
           '';
         };
 
-        # Create an ISO file with the beacon.
-        #
-        # This ISO file will need to be burned on a USB stick.
-        # This can be done for example with usbimager that's
-        # included in the template.
-        beacon = inputs.nixos-generators.nixosGenerate {
-          inherit system;
-          format = "install-iso";
+        mkHostPackages =
+          name: cfg':
+          let
+            hostCfg = topLevelConfig.flake.nixosConfigurations.${name}.config;
 
-          modules = cfg'.extraBeaconModules ++ [
-            (beacon-module hostCfg)
-          ];
-        };
+            # nix run .#boot-ssh
+            boot-ssh = pkgs.writeShellApplication {
+              name = "boot-ssh";
 
-        # Create and Start a VM that boots the ISO file with the beacon.
-        #
-        # Useful for testing a full installation.
-        # This VM comes with 3 disks, one under /dev/nvme0n1
-        # and the two other under /dev/sda and /dev/sdb. This
-        # setup imitates a real server with one SSD disk for
-        # the OS and two HDDs in mirror for the data.
-        #
-        #   nix run .#beacon-vm [<host-port> [<host-boot-port>]]
-        #
-        #   host-port:        Host part of the port forwarding for the SSH server
-        #                     when the VM is booted.
-        #                     (default: 2222)
-        #   host-boot-port:   Host port of the port forwarding for the SSH server
-        #                     used to decrypt the root partition upon booting
-        #                     or rebooting after the installation process is done.
-        #                     (default: 2223)
-        #
-        beacon-vm = let
-          # About bootindex. On first boot, the nvme* drives cannot boot
-          # so we will instead boot on the cdrom. After a successful installation,
-          # we will be able to boot on the nvme* drives instead.
-          script = targetSystem: (let
-            targetPkgs = import inputs.nixpkgs { system = targetSystem; };
-
-            iso = inputs.nixos-generators.nixosGenerate {
-              system = targetSystem;
-              format = "install-iso";
-
-              modules = [
-                (beacon-module hostCfg)
-                ({ lib, modulesPath, ... }: {
-                  imports = [
-                    # This profile adds virtio drivers needed in the guest
-                    # to be able to share the /nix/store folder.
-                    (modulesPath + "/profiles/qemu-guest.nix")
-                  ];
-                  # Since this is the VM and we will mount the hosts' nix store,
-                  # we do not need to create a squashfs file.
-                  config.isoImage.storeContents = lib.mkForce [];
-
-                  # Share the host's nix store instead of the one created for the ISO.
-                  # config.lib.isoFileSystems is defined in nixos/modules/installer/cd-dvd/iso-image.nix
-                  config.lib.isoFileSystems = {
-                    "/nix/.ro-store" = lib.mkForce {
-                      device = "nix-store";
-                      fsType = "9p";
-                      neededForBoot = true;
-                      options = [
-                        "trans=virtio"
-                        "version=9p2000.L"
-                        "msize=16384"
-                        "x-systemd.requires=modprobe@9pnet_virtio.service"
-                        "cache=loose"
-                      ];
-                    };
-                  };
-
-                  config.boot.kernelParams = [
-                    "console=tty0"
-                    "console=ttyS0,115200"
-                  ];
+              runtimeInputs = [
+                (import ../lib/ssh.nix {
+                  inherit pkgs;
                 })
               ];
+
+              text = ''
+                ssh \
+                  "${cfg'.ip}" \
+                  "${toString cfg'.sshBootPort}" \
+                  root \
+                  -o UserKnownHostsFile=${cfg'.knownHostsPath} \
+                  -o ConnectTimeout=10 \
+                  ${if cfg'.sshPrivateKeyPath != null then "-i ${cfg'.sshPrivateKeyPath}" else ""} \
+                  ${if cfg'.sshPublicKeyPath != null then "-i ${cfg'.sshPublicKeyPath}" else ""} \
+                  "$*"
+              '';
             };
-            nixos-qemu = targetPkgs.callPackage "${pkgs.path}/nixos/lib/qemu-common.nix" {};
-            qemu = nixos-qemu.qemuBinary pkgs.qemu;
-          in pkgs.writeShellScriptBin "beacon-vm" ''
-            diskRoot1=.skarabox-tmp/diskRoot1.qcow2
-            diskRoot2=.skarabox-tmp/diskRoot2.qcow2
-            diskData1=.skarabox-tmp/diskData1.qcow2
-            diskData2=.skarabox-tmp/diskData2.qcow2
 
-            mkdir -p .skarabox-tmp
-            for d in $diskRoot1 $diskRoot2 $diskData1 $diskData2; do
-              [ ! -f $d ] && ${pkgs.qemu}/bin/qemu-img create -f qcow2 $d 20G
-            done
+            # Create an ISO file with the beacon.
+            #
+            # This ISO file will need to be burned on a USB stick.
+            # This can be done for example with usbimager that's
+            # included in the template.
+            beacon = inputs.nixos-generators.nixosGenerate {
+              inherit system;
+              format = "install-iso";
 
-            set -x
+              modules = cfg'.extraBeaconModules ++ [
+                (beacon-module hostCfg)
+              ];
+            };
 
-            guestport=${toString hostCfg.skarabox.sshPort}
-            hostport=${toString cfg'.beacon.sshPort}
-            guestbootport=${toString hostCfg.skarabox.boot.sshPort}
-            hostbootport=${toString cfg'.sshBootPort}
+            # Create and Start a VM that boots the ISO file with the beacon.
+            #
+            # Useful for testing a full installation.
+            # This VM comes with 3 disks, one under /dev/nvme0n1
+            # and the two other under /dev/sda and /dev/sdb. This
+            # setup imitates a real server with one SSD disk for
+            # the OS and two HDDs in mirror for the data.
+            #
+            #   nix run .#beacon-vm [<host-port> [<host-boot-port>]]
+            #
+            #   host-port:        Host part of the port forwarding for the SSH server
+            #                     when the VM is booted.
+            #                     (default: 2222)
+            #   host-boot-port:   Host port of the port forwarding for the SSH server
+            #                     used to decrypt the root partition upon booting
+            #                     or rebooting after the installation process is done.
+            #                     (default: 2223)
+            #
+            beacon-vm =
+              let
+                # About bootindex. On first boot, the nvme* drives cannot boot
+                # so we will instead boot on the cdrom. After a successful installation,
+                # we will be able to boot on the nvme* drives instead.
+                script =
+                  targetSystem:
+                  (
+                    let
+                      targetPkgs = import inputs.nixpkgs { system = targetSystem; };
 
-            ${qemu} \
-              -m 2048M \
-              -device virtio-rng-pci \
-              -net nic -net user,hostfwd=tcp::''${hostport}-:''${guestport},hostfwd=tcp::''${hostbootport}-:''${guestbootport} \
-              --virtfs local,path=/nix/store,security_model=none,mount_tag=nix-store \
-              --drive if=pflash,format=raw,unit=0,readonly=on,file=${targetPkgs.OVMF.firmware} \
-              --drive media=cdrom,format=raw,readonly=on,file=${iso}/iso/beacon.iso \
-              --drive format=qcow2,file=$diskRoot1,if=none,id=diskRoot1 \
-              --device nvme,drive=diskRoot1,serial=nvme0,bootindex=1 \
-              --drive format=qcow2,file=$diskRoot2,if=none,id=diskRoot2 \
-              --device nvme,drive=diskRoot2,serial=nvme1,bootindex=2 \
-              --drive id=diskData1,format=qcow2,if=none,file=$diskData1 \
-              --device ide-hd,drive=diskData1,serial=sda \
-              --drive id=diskData2,format=qcow2,if=none,file=$diskData2 \
-              --device ide-hd,drive=diskData2,serial=sdb \
-              $@
-            '');
-          in
-            script (if system == "x86_64-darwin" then "x86_64-linux"
-                    else if system == "aarch64-darwin" then "aarch64-linux"
-                    else system);
+                      iso = inputs.nixos-generators.nixosGenerate {
+                        system = targetSystem;
+                        format = "install-iso";
 
-          # Generate knownhosts file.
-          #
-          # gen-knownhosts-file <pub_key> <ip> <port> [<port>...]
-          #
-          # One line will be generated per port given.
-          gen-knownhosts-file = pkgs.writeShellApplication {
-            name = "gen-knownhosts-file";
+                        modules = [
+                          (beacon-module hostCfg)
+                          (
+                            { lib, modulesPath, ... }:
+                            {
+                              imports = [
+                                # This profile adds virtio drivers needed in the guest
+                                # to be able to share the /nix/store folder.
+                                (modulesPath + "/profiles/qemu-guest.nix")
+                              ];
+                              # Since this is the VM and we will mount the hosts' nix store,
+                              # we do not need to create a squashfs file.
+                              config.isoImage.storeContents = lib.mkForce [ ];
 
-            runtimeInputs = [
-              (import ../lib/gen-knownhosts-file.nix {
-                inherit pkgs;
-              })
-            ];
+                              # Share the host's nix store instead of the one created for the ISO.
+                              # config.lib.isoFileSystems is defined in nixos/modules/installer/cd-dvd/iso-image.nix
+                              config.lib.isoFileSystems = {
+                                "/nix/.ro-store" = lib.mkForce {
+                                  device = "nix-store";
+                                  fsType = "9p";
+                                  neededForBoot = true;
+                                  options = [
+                                    "trans=virtio"
+                                    "version=9p2000.L"
+                                    "msize=16384"
+                                    "x-systemd.requires=modprobe@9pnet_virtio.service"
+                                    "cache=loose"
+                                  ];
+                                };
+                              };
 
-            text = ''
-              ip=${cfg'.ip}
-              ssh_port=${toString cfg'.sshPort}
-              ssh_boot_port=${toString cfg'.sshBootPort}
-              host_key_pub="${cfg'.hostKeyPub}"
+                              config.boot.kernelParams = [
+                                "console=tty0"
+                                "console=ttyS0,115200"
+                              ];
+                            }
+                          )
+                        ];
+                      };
+                      nixos-qemu = targetPkgs.callPackage "${pkgs.path}/nixos/lib/qemu-common.nix" { };
+                      qemu = nixos-qemu.qemuBinary pkgs.qemu;
+                    in
+                    pkgs.writeShellScriptBin "beacon-vm" ''
+                      diskRoot1=.skarabox-tmp/diskRoot1.qcow2
+                      diskRoot2=.skarabox-tmp/diskRoot2.qcow2
+                      diskData1=.skarabox-tmp/diskData1.qcow2
+                      diskData2=.skarabox-tmp/diskData2.qcow2
 
-              gen-knownhosts-file \
-                "$host_key_pub" "$ip" $ssh_port $ssh_boot_port \
-                >> ${cfg'.knownHostsPath}
-            '';
-          };
+                      mkdir -p .skarabox-tmp
+                      for d in $diskRoot1 $diskRoot2 $diskData1 $diskData2; do
+                        [ ! -f $d ] && ${pkgs.qemu}/bin/qemu-img create -f qcow2 $d 20G
+                      done
 
-          # Install a nixosConfigurations instance (<flake>) on a server.
-          #
-          # This command is intended to be run against a server which
-          # was booted on the beacon. Although, the server could be booted
-          # on any OS supported by nixos-anywhere. The latter has not been
-          # tested in the context of Skarabox.
-          #
-          #   nix run .#install-on-beacon [<command> ...]
-          #   nix run .#install-on-beacon
-          #   nix run .#install-on-beacon -v
-          install-on-beacon = pkgs.writeShellApplication {
-            name = "install-on-beacon";
-            runtimeInputs = [
-              (import ../lib/install-on-beacon.nix {
-                inherit pkgs;
-                inherit (inputs.nixos-anywhere.packages.${system}) nixos-anywhere;
-              })
-              sops
-            ];
-            text = let
-              secrets =
-                {
-                  "root_passphrase" = cfg'.secretsRootPassphrasePath;
-                }
-                // (optionalAttrs hostCfg.skarabox.disks.dataPool.enable {
-                  "data_passphrase" = cfg'.secretsDataPassphrasePath;
-                })
-                // cfg'.extraSecretsPassphrasesPath;
+                      set -x
 
-              diskEncryptionTmpFiles = let
-                mkTmpFile = name: path: ''
-                  echo "Using secret at ${path} in file ${cfg'.secretsFilePath} for ${name}"
-                  secret_file_${name}="$(mktemp -u)"
-                  mkfifo -m 600 "$secret_file_${name}"
-                  trap 'rm -f "$secret_file_${name}"' EXIT
-                  # Write secret to FIFO in background - it will block until read
-                  sops decrypt --extract "${path}" "${cfg'.secretsFilePath}" > "$secret_file_${name}" &
-                '';
+                      guestport=${toString hostCfg.skarabox.sshPort}
+                      hostport=${toString cfg'.beacon.sshPort}
+                      guestbootport=${toString hostCfg.skarabox.boot.sshPort}
+                      hostbootport=${toString cfg'.sshBootPort}
+
+                      ${qemu} \
+                        -m 2048M \
+                        -device virtio-rng-pci \
+                        -net nic -net user,hostfwd=tcp::''${hostport}-:''${guestport},hostfwd=tcp::''${hostbootport}-:''${guestbootport} \
+                        --virtfs local,path=/nix/store,security_model=none,mount_tag=nix-store \
+                        --drive if=pflash,format=raw,unit=0,readonly=on,file=${targetPkgs.OVMF.firmware} \
+                        --drive media=cdrom,format=raw,readonly=on,file=${iso}/iso/beacon.iso \
+                        --drive format=qcow2,file=$diskRoot1,if=none,id=diskRoot1 \
+                        --device nvme,drive=diskRoot1,serial=nvme0,bootindex=1 \
+                        --drive format=qcow2,file=$diskRoot2,if=none,id=diskRoot2 \
+                        --device nvme,drive=diskRoot2,serial=nvme1,bootindex=2 \
+                        --drive id=diskData1,format=qcow2,if=none,file=$diskData1 \
+                        --device ide-hd,drive=diskData1,serial=sda \
+                        --drive id=diskData2,format=qcow2,if=none,file=$diskData2 \
+                        --device ide-hd,drive=diskData2,serial=sdb \
+                        $@
+                    ''
+                  );
               in
-                mapAttrsToList mkTmpFile secrets;
-            in ''
-              ip=${toString cfg'.ip}
-              ssh_port=${toString cfg'.beacon.sshPort}
-              flake=".#${toString name}"
+              script (
+                if system == "x86_64-darwin" then
+                  "x86_64-linux"
+                else if system == "aarch64-darwin" then
+                  "aarch64-linux"
+                else
+                  system
+              );
 
-              export SOPS_AGE_KEY_FILE="${cfg.sopsKeyPath}"
+            # Generate knownhosts file.
+            #
+            # gen-knownhosts-file <pub_key> <ip> <port> [<port>...]
+            #
+            # One line will be generated per port given.
+            gen-knownhosts-file = pkgs.writeShellApplication {
+              name = "gen-knownhosts-file";
 
-              ''
-            + concatStringsSep "\n" diskEncryptionTmpFiles
-            + (let
-                # Build the extra arguments list properly
-                extraArgs = []
-                  ++ [ "--ssh-option" "ConnectTimeout=10" ]
-                  ++ (lib.optionals (cfg'.beacon.sshPrivateKeyPath != null) [ "-i" cfg'.beacon.sshPrivateKeyPath ])
-                  ++ (lib.optionals (cfg'.beacon.sshPublicKeyPath != null) [ "--ssh-public-key" cfg'.beacon.sshPublicKeyPath ])
-                  ++ [ "--disk-encryption-keys" "/tmp/host_key" cfg'.hostKeyPath ]
-                  ++ (lib.flatten (mapAttrsToList (name: path: [ "--disk-encryption-keys" "/tmp/${name}" "\$secret_file_${name}" ]) secrets));
-                
-                # Convert to a bash array declaration
-                argsString = concatStringsSep " " (map (arg: ''"${arg}"'') extraArgs);
-              in ''
+              runtimeInputs = [
+                (import ../lib/gen-knownhosts-file.nix {
+                  inherit pkgs;
+                })
+              ];
 
-              install-on-beacon \
-                -i "$ip" \
-                -u ${cfg'.beacon.username} \
-                -p "$ssh_port" \
-                -f "$flake" \
-                -- \
-                ${argsString} \
-                "$@"
-            '');
+              text = ''
+                ip=${cfg'.ip}
+                ssh_port=${toString cfg'.sshPort}
+                ssh_boot_port=${toString cfg'.sshBootPort}
+                host_key_pub="${cfg'.hostKeyPub}"
+
+                gen-knownhosts-file \
+                  "$host_key_pub" "$ip" $ssh_port $ssh_boot_port \
+                  >> ${cfg'.knownHostsPath}
+              '';
+            };
+
+            # Install a nixosConfigurations instance (<flake>) on a server.
+            #
+            # This command is intended to be run against a server which
+            # was booted on the beacon. Although, the server could be booted
+            # on any OS supported by nixos-anywhere. The latter has not been
+            # tested in the context of Skarabox.
+            #
+            #   nix run .#install-on-beacon [<command> ...]
+            #   nix run .#install-on-beacon
+            #   nix run .#install-on-beacon -v
+            install-on-beacon = pkgs.writeShellApplication {
+              name = "install-on-beacon";
+              runtimeInputs = [
+                (import ../lib/install-on-beacon.nix {
+                  inherit pkgs;
+                  inherit (inputs.nixos-anywhere.packages.${system}) nixos-anywhere;
+                })
+                sops
+              ];
+              text =
+                let
+                  secrets = {
+                    "root_passphrase" = cfg'.secretsRootPassphrasePath;
+                  }
+                  // (optionalAttrs hostCfg.skarabox.disks.dataPool.enable {
+                    "data_passphrase" = cfg'.secretsDataPassphrasePath;
+                  })
+                  // cfg'.extraSecretsPassphrasesPath;
+
+                  diskEncryptionTmpFiles =
+                    let
+                      mkTmpFile = name: path: ''
+                        echo "Using secret at ${path} in file ${cfg'.secretsFilePath} for ${name}"
+                        secret_file_${name}="$(mktemp -u)"
+                        mkfifo -m 600 "$secret_file_${name}"
+                        trap 'rm -f "$secret_file_${name}"' EXIT
+                        # Write secret to FIFO in background - it will block until read
+                        sops decrypt --extract "${path}" "${cfg'.secretsFilePath}" > "$secret_file_${name}" &
+                      '';
+                    in
+                    mapAttrsToList mkTmpFile secrets;
+                in
+                ''
+                  ip=${toString cfg'.ip}
+                  ssh_port=${toString cfg'.beacon.sshPort}
+                  flake=".#${toString name}"
+
+                  export SOPS_AGE_KEY_FILE="${cfg.sopsKeyPath}"
+
+                ''
+                + concatStringsSep "\n" diskEncryptionTmpFiles
+                + (
+                  let
+                    # Build the extra arguments list properly
+                    extraArgs =
+                      [ ]
+                      ++ [
+                        "--ssh-option"
+                        "ConnectTimeout=10"
+                      ]
+                      ++ (lib.optionals (cfg'.beacon.sshPrivateKeyPath != null) [
+                        "-i"
+                        cfg'.beacon.sshPrivateKeyPath
+                      ])
+                      ++ (lib.optionals (cfg'.beacon.sshPublicKeyPath != null) [
+                        "--ssh-public-key"
+                        cfg'.beacon.sshPublicKeyPath
+                      ])
+                      ++ [
+                        "--disk-encryption-keys"
+                        "/tmp/host_key"
+                        cfg'.hostKeyPath
+                      ]
+                      ++ (lib.flatten (
+                        mapAttrsToList (name: path: [
+                          "--disk-encryption-keys"
+                          "/tmp/${name}"
+                          "\$secret_file_${name}"
+                        ]) secrets
+                      ));
+
+                    # Convert to a bash array declaration
+                    argsString = concatStringsSep " " (map (arg: ''"${arg}"'') extraArgs);
+                  in
+                  ''
+
+                    install-on-beacon \
+                      -i "$ip" \
+                      -u ${cfg'.beacon.username} \
+                      -p "$ssh_port" \
+                      -f "$flake" \
+                      -- \
+                      ${argsString} \
+                      "$@"
+                  ''
+                );
+            };
+
+            # nix run .#ssh [<command> ...]
+            # nix run .#ssh
+            # nix run .#ssh echo hello
+            #
+            # Note: the private SSH key is not read into the nix store on purpose.
+            ssh = pkgs.writeShellApplication {
+              name = "ssh";
+
+              runtimeInputs = [
+                (import ../lib/ssh.nix {
+                  inherit pkgs;
+                })
+              ];
+
+              text = ''
+                ssh \
+                  "${cfg'.ip}" \
+                  "${toString cfg'.sshPort}" \
+                  ${hostCfg.skarabox.username} \
+                  -o UserKnownHostsFile=${cfg'.knownHostsPath} \
+                  -o ConnectTimeout=10 \
+                  ${if cfg'.sshPrivateKeyPath != null then "-i ${cfg'.sshPrivateKeyPath}" else ""} \
+                  ${if cfg'.sshPublicKeyPath != null then "-i ${cfg'.sshPublicKeyPath}" else ""} \
+                  "$@"
+              '';
+            };
+
+            ssh-beacon = pkgs.writeShellApplication {
+              name = "ssh";
+
+              runtimeInputs = [
+                (import ../lib/ssh.nix {
+                  inherit pkgs;
+                })
+              ];
+
+              text = ''
+                ssh \
+                  "${cfg'.ip}" \
+                  "${toString cfg'.beacon.sshPort}" \
+                  ${cfg'.beacon.username} \
+                  -o ConnectTimeout=10 \
+                  -o StrictHostKeyChecking=accept-new \
+                  -o UserKnownHostsFile=/dev/null \
+                  ${if cfg'.beacon.sshPrivateKeyPath != null then "-i ${cfg'.beacon.sshPrivateKeyPath}" else ""} \
+                  ${if cfg'.beacon.sshPublicKeyPath != null then "-i ${cfg'.beacon.sshPublicKeyPath}" else ""} \
+                  "$@"
+              '';
+            };
+
+            get-facter = import ../lib/get-facter.nix {
+              inherit name pkgs ssh-beacon;
+            };
+
+            unlock = pkgs.writeShellApplication {
+              name = "unlock";
+
+              runtimeInputs = [
+                sops
+                boot-ssh
+              ];
+
+              # skarabox-unlock-root answers systemd's ask-password request directly,
+              # so this path must not allocate a TTY that could echo the passphrase.
+              text = ''
+                root_passphrase="$(sops decrypt --extract "${cfg'.secretsRootPassphrasePath}" "${cfg'.secretsFilePath}")"
+                printf '%s\n' "$root_passphrase" | boot-ssh -T "$@"
+              '';
+            };
+          in
+          {
+            "${name}-boot-ssh" = boot-ssh;
+            "${name}-sops" = sops;
+            "${name}-beacon" = beacon;
+            "${name}-beacon-vm" = beacon-vm;
+            "${name}-ssh-beacon" = ssh-beacon;
+            "${name}-gen-knownhosts-file" = gen-knownhosts-file;
+            "${name}-install-on-beacon" = install-on-beacon;
+            "${name}-ssh" = ssh;
+            "${name}-get-facter" = get-facter;
+            "${name}-unlock" = unlock;
           };
+      in
+      {
+        packages = {
+          beacon-usbimager = pkgs.usbimager;
+          inherit sops;
+          inherit (pkgs) age;
+          inherit (inputs'.skarabox.packages)
+            gen-hostId
+            gen-new-host
+            manualHtml
+            add-sops-cfg
+            sops-add-main-key
+            sops-create-main-key
+            ;
+        }
+        // (concatMapAttrs mkHostPackages cfg.hosts);
+      };
 
-          # nix run .#ssh [<command> ...]
-          # nix run .#ssh
-          # nix run .#ssh echo hello
-          #
-          # Note: the private SSH key is not read into the nix store on purpose.
-          ssh = pkgs.writeShellApplication {
-            name = "ssh";
+    flake =
+      flakeInputs:
+      let
+        # First, build all nixosConfigurations
+        allNixosConfigurations = concatMapAttrs (
+          name: cfg':
+          let
+            nixpkgs' = if cfg'.nixpkgs != null then cfg'.nixpkgs else inputs.nixpkgs;
+            pkgs' = import nixpkgs' {
+              inherit (cfg') system;
+            };
+          in
+          {
+            ${name} = skaraboxLib.nixosSystem {
+              inherit nixpkgs';
+              inherit (pkgs') lib;
 
-            runtimeInputs = [
-              (import ../lib/ssh.nix {
-                inherit pkgs;
-              })
-            ];
+              inherit (cfg') system specialArgs;
+              modules = cfg'.modules ++ [
+                inputs.skarabox.nixosModules.skarabox
+                {
+                  nixpkgs.hostPlatform = cfg'.system;
+                }
+              ];
+            };
+          }
+        ) cfg.hosts;
 
-            text = ''
-              ssh \
-                "${cfg'.ip}" \
-                "${toString cfg'.sshPort}" \
-                ${hostCfg.skarabox.username} \
-                -o UserKnownHostsFile=${cfg'.knownHostsPath} \
-                -o ConnectTimeout=10 \
-                ${if cfg'.sshPrivateKeyPath != null then "-i ${cfg'.sshPrivateKeyPath}" else ""} \
-                ${if cfg'.sshPublicKeyPath != null then "-i ${cfg'.sshPublicKeyPath}" else ""} \
-                "$@"
-            '';
-          };
+        # Build packages lazily by grouping hosts by system, then creating packages per host.
+        # Using groupBy + mapAttrs + listToAttrs maintains laziness: only accessed packages
+        # trigger evaluation of their host. Each host's packages reference nixosConfigurations
+        # directly, so they remain lazy thunks until accessed.
+        hostsBySystem = lib.groupBy (name: cfg.hosts.${name}.system) (lib.attrNames cfg.hosts);
 
-          ssh-beacon = pkgs.writeShellApplication {
-            name = "ssh";
+        allPackages = lib.mapAttrs (
+          system: hostNames:
+          lib.listToAttrs (
+            lib.concatMap (name: [
+              {
+                name = name;
+                value = allNixosConfigurations.${name}.config.system.build.toplevel;
+              }
+              {
+                name = "${name}-debug-facter-nvd";
+                value = allNixosConfigurations.${name}.config.hardware.facter.debug.nvd;
+              }
+              {
+                name = "${name}-debug-facter-nix-diff";
+                value = allNixosConfigurations.${name}.config.hardware.facter.debug.nix-diff;
+              }
+            ]) hostNames
+          )
+        ) hostsBySystem;
 
-            runtimeInputs = [
-              (import ../lib/ssh.nix {
-                inherit pkgs;
-              })
-            ];
-
-            text = ''
-              ssh \
-                "${cfg'.ip}" \
-                "${toString cfg'.beacon.sshPort}" \
-                ${cfg'.beacon.username} \
-                -o ConnectTimeout=10 \
-                -o StrictHostKeyChecking=accept-new \
-                -o UserKnownHostsFile=/dev/null \
-                ${if cfg'.beacon.sshPrivateKeyPath != null then "-i ${cfg'.beacon.sshPrivateKeyPath}" else ""} \
-                ${if cfg'.beacon.sshPublicKeyPath != null then "-i ${cfg'.beacon.sshPublicKeyPath}" else ""} \
-                "$@"
-            '';
-          };
-
-          get-facter = import ../lib/get-facter.nix {
-            inherit name pkgs ssh-beacon;
-          };
-
-          unlock = pkgs.writeShellApplication {
-            name = "unlock";
-
-            runtimeInputs = [
-              sops
-              boot-ssh
-            ];
-
-            # skarabox-unlock-root answers systemd's ask-password request directly,
-            # so this path must not allocate a TTY that could echo the passphrase.
-            text = ''
-              root_passphrase="$(sops decrypt --extract "${cfg'.secretsRootPassphrasePath}" "${cfg'.secretsFilePath}")"
-              printf '%s\n' "$root_passphrase" | boot-ssh -T "$@"
-            '';
-          };
-        in {
-          "${name}-boot-ssh" = boot-ssh;
-          "${name}-sops" = sops;
-          "${name}-beacon" = beacon;
-          "${name}-beacon-vm" = beacon-vm;
-          "${name}-ssh-beacon" = ssh-beacon;
-          "${name}-gen-knownhosts-file" = gen-knownhosts-file;
-          "${name}-install-on-beacon" = install-on-beacon;
-          "${name}-ssh" = ssh;
-          "${name}-get-facter" = get-facter;
-          "${name}-unlock" = unlock;
-        };
-    in {
-      packages = {
-        beacon-usbimager = pkgs.usbimager;
-        inherit sops;
-        inherit (pkgs) age;
-        inherit (inputs'.skarabox.packages) gen-hostId gen-new-host manualHtml add-sops-cfg sops-add-main-key sops-create-main-key;
-      } // (concatMapAttrs mkHostPackages cfg.hosts);
-    };
-
-    flake = flakeInputs: let
-      # First, build all nixosConfigurations
-      allNixosConfigurations = concatMapAttrs (name: cfg': let
-        nixpkgs' = if cfg'.nixpkgs != null then cfg'.nixpkgs else inputs.nixpkgs;
-        pkgs' = import nixpkgs' {
-          inherit (cfg') system;
-        };
-      in {
-        ${name} = skaraboxLib.nixosSystem {
-          inherit nixpkgs';
-          inherit (pkgs') lib;
-
-          inherit (cfg') system specialArgs;
-          modules = cfg'.modules ++ [
-            inputs.skarabox.nixosModules.skarabox
-            {
-              nixpkgs.hostPlatform = cfg'.system;
-            }
-          ];
-        };
-      }) cfg.hosts;
-
-      # Build packages lazily by grouping hosts by system, then creating packages per host.
-      # Using groupBy + mapAttrs + listToAttrs maintains laziness: only accessed packages
-      # trigger evaluation of their host. Each host's packages reference nixosConfigurations
-      # directly, so they remain lazy thunks until accessed.
-      hostsBySystem = lib.groupBy (name: cfg.hosts.${name}.system) (lib.attrNames cfg.hosts);
-      
-      allPackages = lib.mapAttrs (system: hostNames:
-        lib.listToAttrs (lib.concatMap (name: [
-          { name = name; value = allNixosConfigurations.${name}.config.system.build.toplevel; }
-          { name = "${name}-debug-facter-nvd"; value = allNixosConfigurations.${name}.config.hardware.facter.debug.nvd; }
-          { name = "${name}-debug-facter-nix-diff"; value = allNixosConfigurations.${name}.config.hardware.facter.debug.nix-diff; }
-        ]) hostNames)
-      ) hostsBySystem;
-
-    in {
-      nixosModules.beacon = beacon-module;
-      nixosConfigurations = allNixosConfigurations;
-      packages = allPackages;
-    };
+      in
+      {
+        nixosModules.beacon = beacon-module;
+        nixosConfigurations = allNixosConfigurations;
+        packages = allPackages;
+      };
   };
 }

--- a/flakeModules/deploy-rs.nix
+++ b/flakeModules/deploy-rs.nix
@@ -21,72 +21,97 @@ in
           # We don't do strict typing here, we let deploy-rs deal with it.
           # If we want better typing, we should upstream this in flake-parts directly.
           type = lib.types.attrsOf lib.types.anything;
-          default = {};
+          default = { };
         };
       };
     };
   };
 
   config = {
-    perSystem = { self', inputs', config, pkgs, system, ... }: {
-      apps = {
-        inherit (inputs'.deploy-rs.apps) deploy-rs;
+    perSystem =
+      {
+        self',
+        inputs',
+        config,
+        pkgs,
+        system,
+        ...
+      }:
+      {
+        apps = {
+          inherit (inputs'.deploy-rs.apps) deploy-rs;
+        };
       };
-    };
 
-    flake = flakeInputs: let
-      mkFlake = name: cfg': {
-        # Debug eval errors with `nix eval --json .#deploy --show-trace`
-        deploy.nodes = let
-          pkgs' = import inputs.nixpkgs {
-            inherit (cfg') system;
-          };
-          # Use deploy-rs from nixpkgs to take advantage of the binary cache.
-          # https://github.com/serokell/deploy-rs?tab=readme-ov-file#overall-usage
-          deployPkgs = import inputs.nixpkgs {
-            inherit (cfg') system;
-            overlays = [
-              inputs.deploy-rs.overlays.default
-              (self: super: {
-                deploy-rs = {
-                  inherit (pkgs') deploy-rs;
-                  lib = super.deploy-rs.lib;
-                };
-              })
-            ];
-          };
-
-          mkNode = name: cfg': let
-            hostCfg = topLevelConfig.flake.nixosConfigurations.${name}.config;
-          in {
-            ${name} = {
-              hostname = cfg'.ip;
-              sshUser = topLevelConfig.flake.nixosConfigurations.${name}.config.skarabox.username;
-              # What out, adding --ssh-opts on the command line will override these args.
-              # For example, running `nix run .#deploy-rs -- -s --ssh-opts -v` will result in only the -v flag.
-              sshOpts = [
-                "-o" "IdentitiesOnly=yes"
-                "-o" "UserKnownHostsFile=${cfg'.knownHostsPath}"
-                "-o" "ConnectTimeout=10"
-                "-p" (toString hostCfg.skarabox.sshPort)
-              ] ++ lib.optionals (cfg'.sshPrivateKeyPath != null) [ "-i" cfg'.sshPrivateKeyPath ];
-              profiles = {
-                system = {
-                  user = "root";
-                  path = deployPkgs.deploy-rs.lib.activate.nixos topLevelConfig.flake.nixosConfigurations.${name};
-                };
+    flake =
+      flakeInputs:
+      let
+        mkFlake = name: cfg': {
+          # Debug eval errors with `nix eval --json .#deploy --show-trace`
+          deploy.nodes =
+            let
+              pkgs' = import inputs.nixpkgs {
+                inherit (cfg') system;
               };
-            };
-          };
-          in
-            concatMapAttrs mkNode cfg.hosts;
-      };
+              # Use deploy-rs from nixpkgs to take advantage of the binary cache.
+              # https://github.com/serokell/deploy-rs?tab=readme-ov-file#overall-usage
+              deployPkgs = import inputs.nixpkgs {
+                inherit (cfg') system;
+                overlays = [
+                  inputs.deploy-rs.overlays.default
+                  (self: super: {
+                    deploy-rs = {
+                      inherit (pkgs') deploy-rs;
+                      lib = super.deploy-rs.lib;
+                    };
+                  })
+                ];
+              };
 
-      common = {
-        # From https://github.com/serokell/deploy-rs?tab=readme-ov-file#overall-usage
-        checks = builtins.mapAttrs (system: deployLib: deployLib.deployChecks topLevelConfig.flake.deploy) inputs.deploy-rs.lib;
-      };
-    in
+              mkNode =
+                name: cfg':
+                let
+                  hostCfg = topLevelConfig.flake.nixosConfigurations.${name}.config;
+                in
+                {
+                  ${name} = {
+                    hostname = cfg'.ip;
+                    sshUser = topLevelConfig.flake.nixosConfigurations.${name}.config.skarabox.username;
+                    # What out, adding --ssh-opts on the command line will override these args.
+                    # For example, running `nix run .#deploy-rs -- -s --ssh-opts -v` will result in only the -v flag.
+                    sshOpts = [
+                      "-o"
+                      "IdentitiesOnly=yes"
+                      "-o"
+                      "UserKnownHostsFile=${cfg'.knownHostsPath}"
+                      "-o"
+                      "ConnectTimeout=10"
+                      "-p"
+                      (toString hostCfg.skarabox.sshPort)
+                    ]
+                    ++ lib.optionals (cfg'.sshPrivateKeyPath != null) [
+                      "-i"
+                      cfg'.sshPrivateKeyPath
+                    ];
+                    profiles = {
+                      system = {
+                        user = "root";
+                        path = deployPkgs.deploy-rs.lib.activate.nixos topLevelConfig.flake.nixosConfigurations.${name};
+                      };
+                    };
+                  };
+                };
+            in
+            concatMapAttrs mkNode cfg.hosts;
+        };
+
+        common = {
+          # From https://github.com/serokell/deploy-rs?tab=readme-ov-file#overall-usage
+          checks = builtins.mapAttrs (
+            system: deployLib: deployLib.deployChecks topLevelConfig.flake.deploy
+          ) inputs.deploy-rs.lib;
+        };
+      in
       common // (concatMapAttrs mkFlake cfg.hosts);
   };
 }

--- a/lib/add-sops-cfg.nix
+++ b/lib/add-sops-cfg.nix
@@ -1,5 +1,5 @@
 {
-  pkgs
+  pkgs,
 }:
 pkgs.writers.writePython3Bin "add-sops-cfg"
   {

--- a/lib/functions.nix
+++ b/lib/functions.nix
@@ -9,14 +9,18 @@
     import "${nixpkgs'}/nixos/lib/eval-config.nix" (
       {
         system = null;
-        modules = (args.modules or []) ++ [
-          ({ config, pkgs, ... }:
+        modules = (args.modules or [ ]) ++ [
+          (
+            { config, pkgs, ... }:
             {
               nixpkgs.flake.source = nixpkgs.outPath;
             }
           )
         ];
       }
-      // builtins.removeAttrs args [ "modules" "nixpkgs'" ]
+      // builtins.removeAttrs args [
+        "modules"
+        "nixpkgs'"
+      ]
     );
 }

--- a/lib/gen-initial.nix
+++ b/lib/gen-initial.nix
@@ -7,7 +7,7 @@
 pkgs.writeShellApplication {
   name = "gen-initial";
 
-  runtimeInputs  = [
+  runtimeInputs = [
     sops-create-main-key
     sops-add-main-key
     gen-new-host
@@ -20,106 +20,108 @@ pkgs.writeShellApplication {
     pkgs.util-linux
   ];
 
-  text = let
-    nix = "nix --extra-experimental-features nix-command -L";
-  in ''
-    set -e
-    set -o pipefail
+  text =
+    let
+      nix = "nix --extra-experimental-features nix-command -L";
+    in
+    ''
+          set -e
+          set -o pipefail
 
-    name=myskarabox
-    yes=0
-    verbose=
+          name=myskarabox
+          yes=0
+          verbose=
 
-    usage () {
-      cat <<USAGE
-Usage: $0 [-h] [-n] [-y] [-s] [-v]
+          usage () {
+            cat <<USAGE
+      Usage: $0 [-h] [-n] [-y] [-s] [-v]
 
-  -h:        Shows this usage
-  -y:        Answer yes to all questions
-  -s:        Take user password from stdin. Only useful
-             in scripts.
-  -v:        Shows what commands are being run.
-USAGE
-    }
+        -h:        Shows this usage
+        -y:        Answer yes to all questions
+        -s:        Take user password from stdin. Only useful
+                   in scripts.
+        -v:        Shows what commands are being run.
+      USAGE
+          }
 
-    args=()
-    while getopts ":hn:ysv" o; do
-      case "''${o}" in
-        h)
-          usage
-          exit 0
-          ;;
-        y)
+          args=()
+          while getopts ":hn:ysv" o; do
+            case "''${o}" in
+              h)
+                usage
+                exit 0
+                ;;
+              y)
+                args+=(-y)
+                yes=1
+                ;;
+              s)
+                args+=(-s)
+                ;;
+              v)
+                args+=(-v)
+                verbose=1
+                ;;
+              *)
+                usage
+                exit 1
+                ;;
+            esac
+          done
+          shift $((OPTIND-1))
+
+          e () {
+            echo -e "\e[1;31mSKARABOX:\e[0m \e[1;0m$*\e[0m"
+          }
+
+          # From https://stackoverflow.com/a/29436423/1013628
+          yes_or_no () {
+            while true; do
+              echo -ne "\e[1;31mSKARABOX:\e[0m "
+              if [ "$yes" -eq 1 ]; then
+                echo "$* Forced yes"
+                return 0
+              else
+                read -rp "$* [y/n]: " yn
+                case $yn in
+                  [Yy]*) return 0 ;;
+                  [Nn]*) echo "Aborting" ; exit 2 ;;
+                esac
+              fi
+            done
+          }
+
+          if [ -n "$verbose" ]; then
+            set -x
+          fi
+
+          e "This script will initiate a Skarabox template in the current directory."
+          yes_or_no "Most of the steps are automatic but there are some instructions you'll need to follow manually at the end, continue?"
+
+          if [ "$(find . -mindepth 1 | wc -l)" -gt 0 ]; then
+            e "Current directory is not empty, aborting."
+            exit 1
+          fi
+
+          ${nix} flake init --template ${../.}
+
+          e "Now, we will generate the global secrets."
+
+          sops_key="./sops.key"
+          e "Generating main sops key in $sops_key..."
+          rm $sops_key && sops-create-main-key $sops_key
+
+          sops_cfg="./.sops.yaml"
+          e "Creating initial SOPS config in $sops_cfg..."
+          rm $sops_cfg && sops-add-main-key $sops_key $sops_cfg
+
+          e "Now, we will generate the secrets for $name."
+
+          # We delete the files coming from the template and generate them instead.
+          rm -rf myskarabox
+          # We force yes because if we came to here, we said yes earlier.
           args+=(-y)
-          yes=1
-          ;;
-        s)
-          args+=(-s)
-          ;;
-        v)
-          args+=(-v)
-          verbose=1
-          ;;
-        *)
-          usage
-          exit 1
-          ;;
-      esac
-    done
-    shift $((OPTIND-1))
-
-    e () {
-      echo -e "\e[1;31mSKARABOX:\e[0m \e[1;0m$*\e[0m"
-    }
-
-    # From https://stackoverflow.com/a/29436423/1013628
-    yes_or_no () {
-      while true; do
-        echo -ne "\e[1;31mSKARABOX:\e[0m "
-        if [ "$yes" -eq 1 ]; then
-          echo "$* Forced yes"
-          return 0
-        else
-          read -rp "$* [y/n]: " yn
-          case $yn in
-            [Yy]*) return 0 ;;
-            [Nn]*) echo "Aborting" ; exit 2 ;;
-          esac
-        fi
-      done
-    }
-
-    if [ -n "$verbose" ]; then
-      set -x
-    fi
-
-    e "This script will initiate a Skarabox template in the current directory."
-    yes_or_no "Most of the steps are automatic but there are some instructions you'll need to follow manually at the end, continue?"
-
-    if [ "$(find . -mindepth 1 | wc -l)" -gt 0 ]; then
-      e "Current directory is not empty, aborting."
-      exit 1
-    fi
-
-    ${nix} flake init --template ${../.}
-
-    e "Now, we will generate the global secrets."
-
-    sops_key="./sops.key"
-    e "Generating main sops key in $sops_key..."
-    rm $sops_key && sops-create-main-key $sops_key
-
-    sops_cfg="./.sops.yaml"
-    e "Creating initial SOPS config in $sops_cfg..."
-    rm $sops_cfg && sops-add-main-key $sops_key $sops_cfg
-
-    e "Now, we will generate the secrets for $name."
-
-    # We delete the files coming from the template and generate them instead.
-    rm -rf myskarabox
-    # We force yes because if we came to here, we said yes earlier.
-    args+=(-y)
-    gen-new-host "''${args[@]}" "$name"
-  '';
+          gen-new-host "''${args[@]}" "$name"
+    '';
 
 }

--- a/lib/gen-knownhosts-file.nix
+++ b/lib/gen-knownhosts-file.nix
@@ -1,5 +1,5 @@
 {
-  pkgs
+  pkgs,
 }:
 # Generate knownhosts file.
 #

--- a/lib/gen-new-host.nix
+++ b/lib/gen-new-host.nix
@@ -8,7 +8,7 @@
 pkgs.writeShellApplication {
   name = "gen-new-host";
 
-  runtimeInputs  = [
+  runtimeInputs = [
     add-sops-cfg
     pkgs.gnused
     pkgs.mkpasswd
@@ -20,159 +20,159 @@ pkgs.writeShellApplication {
   ];
 
   text = ''
-    set -e
-    set -o pipefail
+        set -e
+        set -o pipefail
 
-    yes=0
-    mkpasswdargs=
-    verbose=
+        yes=0
+        mkpasswdargs=
+        verbose=
 
-    usage () {
-      cat <<USAGE
-Usage: $0 [-h] [-y] [-s] [-v] -n HOSTNAME
+        usage () {
+          cat <<USAGE
+    Usage: $0 [-h] [-y] [-s] [-v] -n HOSTNAME
 
-  The only required argument, HOSTNAME, is the hostname
-  you want to give to the new host. It will also be used
-  as a nickname for the host in the nix configuration.
+      The only required argument, HOSTNAME, is the hostname
+      you want to give to the new host. It will also be used
+      as a nickname for the host in the nix configuration.
 
-  -h:        Shows this usage
-  -y:        Answer yes to all questions
-  -s:        Take user password from stdin. Only useful
-             in scripts.
-  -v:        Shows what commands are being run.
-  -n:        Generate files for this hostname.
-USAGE
-    }
+      -h:        Shows this usage
+      -y:        Answer yes to all questions
+      -s:        Take user password from stdin. Only useful
+                 in scripts.
+      -v:        Shows what commands are being run.
+      -n:        Generate files for this hostname.
+    USAGE
+        }
 
-    while getopts "hynsv" o; do
-      case "''${o}" in
-        h)
-          usage
-          exit 0
-          ;;
-        y)
-          yes=1
-          ;;
-        s)
-          mkpasswdargs=-s
-          ;;
-        v)
-          verbose=1
-          ;;
-        *)
-          usage
-          exit 1
-          ;;
-      esac
-    done
-    shift $((OPTIND-1))
-
-    hostname=$1
-    if [ -z "$hostname" ]; then
-      echo "Please give a hostname. Add -h for usage."
-      exit 1
-    fi
-
-    e () {
-      echo -e "\e[1;31mSKARABOX:\e[0m \e[1;0m$*\e[0m"
-    }
-
-    # From https://stackoverflow.com/a/29436423/1013628
-    yes_or_no () {
-      while true; do
-        echo -ne "\e[1;31mSKARABOX:\e[0m "
-        if [ "$yes" -eq 1 ]; then
-          echo "$* Forced yes"
-          return 0
-        else
-          read -rp "$* [y/n]: " yn
-          case $yn in
-            [Yy]*) return 0 ;;
-            [Nn]*) echo "Aborting" ; exit 2 ;;
+        while getopts "hynsv" o; do
+          case "''${o}" in
+            h)
+              usage
+              exit 0
+              ;;
+            y)
+              yes=1
+              ;;
+            s)
+              mkpasswdargs=-s
+              ;;
+            v)
+              verbose=1
+              ;;
+            *)
+              usage
+              exit 1
+              ;;
           esac
+        done
+        shift $((OPTIND-1))
+
+        hostname=$1
+        if [ -z "$hostname" ]; then
+          echo "Please give a hostname. Add -h for usage."
+          exit 1
         fi
-      done
-    }
 
-    if [ -n "$verbose" ]; then
-      set -x
-    fi
+        e () {
+          echo -e "\e[1;31mSKARABOX:\e[0m \e[1;0m$*\e[0m"
+        }
 
-    e "This script will create a new folder ./$hostname and initiate the template and secrets to manage a host using Skarabox."
-    yes_or_no "Most of the steps are automatic but there are some instructions you'll need to follow manually at the end, continue?"
+        # From https://stackoverflow.com/a/29436423/1013628
+        yes_or_no () {
+          while true; do
+            echo -ne "\e[1;31mSKARABOX:\e[0m "
+            if [ "$yes" -eq 1 ]; then
+              echo "$* Forced yes"
+              return 0
+            else
+              read -rp "$* [y/n]: " yn
+              case $yn in
+                [Yy]*) return 0 ;;
+                [Nn]*) echo "Aborting" ; exit 2 ;;
+              esac
+            fi
+          done
+        }
 
-    if [ -e "$hostname" ]; then
-      e "Cannot create $hostname folder as it already exists. Please remove it or use another hostname."
-      exit 1
-    fi
+        if [ -n "$verbose" ]; then
+          set -x
+        fi
 
-    mkdir -p "$hostname"
+        e "This script will create a new folder ./$hostname and initiate the template and secrets to manage a host using Skarabox."
+        yes_or_no "Most of the steps are automatic but there are some instructions you'll need to follow manually at the end, continue?"
 
-    configuration="$hostname/configuration.nix"
-    e "Generating $configuration"
-    cp ${../template/myskarabox/configuration.nix} "$configuration"
-    chmod u+w "$configuration"
-    sed -i "s/myskarabox/$hostname/" "$configuration"
+        if [ -e "$hostname" ]; then
+          e "Cannot create $hostname folder as it already exists. Please remove it or use another hostname."
+          exit 1
+        fi
 
-    host_key="./$hostname/host_key"
-    host_key_pub="$host_key.pub"
-    e "Generating server host key in $host_key and $host_key.pub..."
-    ssh-keygen -t ed25519 -N "" -f "$host_key" && chmod 600 "$host_key"
+        mkdir -p "$hostname"
 
-    ssh_key="./$hostname/ssh"
-    e "Generating ssh key in $ssh_key and $ssh_key.pub..."
-    ssh-keygen -t ed25519 -N "" -f "$ssh_key" && chmod 600 "$ssh_key"
+        configuration="$hostname/configuration.nix"
+        e "Generating $configuration"
+        cp ${../template/myskarabox/configuration.nix} "$configuration"
+        chmod u+w "$configuration"
+        sed -i "s/myskarabox/$hostname/" "$configuration"
 
-    e "Generating hostid..."
-    sed -i "s/\(skarabox.hostId =\) null;/\1 \"$(${lib.getExe gen-hostId})\";/" "$configuration"
+        host_key="./$hostname/host_key"
+        host_key_pub="$host_key.pub"
+        e "Generating server host key in $host_key and $host_key.pub..."
+        ssh-keygen -t ed25519 -N "" -f "$host_key" && chmod 600 "$host_key"
 
-    e "Generating machineid..."
-    sed -i "s/\(skarabox.machineId =\) null;/\1 \"$(${lib.getExe gen-machineId})\";/" "$configuration"
+        ssh_key="./$hostname/ssh"
+        e "Generating ssh key in $ssh_key and $ssh_key.pub..."
+        ssh-keygen -t ed25519 -N "" -f "$ssh_key" && chmod 600 "$ssh_key"
 
-    sops_cfg="./.sops.yaml"
-    secrets="$hostname/secrets.yaml"
-    e "Adding host key in $sops_cfg..."
-    host_age_key="$(ssh-to-age -i "$host_key_pub")"
-    add-sops-cfg -o "$sops_cfg" alias "$hostname" "$host_age_key"
-    add-sops-cfg -o "$sops_cfg" path-regex main "$secrets"
-    add-sops-cfg -o "$sops_cfg" path-regex "$hostname" "$secrets"
+        e "Generating hostid..."
+        sed -i "s/\(skarabox.hostId =\) null;/\1 \"$(${lib.getExe gen-hostId})\";/" "$configuration"
 
-    sops_key="./sops.key"
-    export SOPS_AGE_KEY_FILE=$sops_key
-    e "Generating sops secrets file $secrets..."
-    echo "tmp_secret: a" > "$secrets"
-    sops encrypt -i "$secrets"
+        e "Generating machineid..."
+        sed -i "s/\(skarabox.machineId =\) null;/\1 \"$(${lib.getExe gen-machineId})\";/" "$configuration"
 
-    e "Generating initial password for user in $secrets under $hostname/user/hashedPassword"
-    sops set "$secrets" \
-      "['$hostname']['user']['hashedPassword']" \
-      "\"$(mkpasswd $mkpasswdargs)\""
+        sops_cfg="./.sops.yaml"
+        secrets="$hostname/secrets.yaml"
+        e "Adding host key in $sops_cfg..."
+        host_age_key="$(ssh-to-age -i "$host_key_pub")"
+        add-sops-cfg -o "$sops_cfg" alias "$hostname" "$host_age_key"
+        add-sops-cfg -o "$sops_cfg" path-regex main "$secrets"
+        add-sops-cfg -o "$sops_cfg" path-regex "$hostname" "$secrets"
 
-    e "Generating root pool passphrase in $secrets under $hostname/disks/rootPassphrase"
-    sops set "$secrets" \
-      "['$hostname']['disks']['rootPassphrase']" \
-      "\"$(openssl rand -hex 64)\""
+        sops_key="./sops.key"
+        export SOPS_AGE_KEY_FILE=$sops_key
+        e "Generating sops secrets file $secrets..."
+        echo "tmp_secret: a" > "$secrets"
+        sops encrypt -i "$secrets"
 
-    e "Generating data pool passphrase in $secrets under $hostname/disks/dataPassphrase"
-    sops set "$secrets" \
-      "['$hostname']['disks']['dataPassphrase']" \
-      "\"$(openssl rand -hex 64)\""
+        e "Generating initial password for user in $secrets under $hostname/user/hashedPassword"
+        sops set "$secrets" \
+          "['$hostname']['user']['hashedPassword']" \
+          "\"$(mkpasswd $mkpasswdargs)\""
 
-    sops unset "$secrets" \
-      "['tmp_secret']"
+        e "Generating root pool passphrase in $secrets under $hostname/disks/rootPassphrase"
+        sops set "$secrets" \
+          "['$hostname']['disks']['rootPassphrase']" \
+          "\"$(openssl rand -hex 64)\""
 
-    e ""
-    e "READ THIS"
-    e ""
-    e "> You are now at step B of the installation process."
-    e ""
-    e "> For the remaining steps, either build the manual locally:"
-    e ">   nix build .#manualHtml"
-    e "> Then open the file ./result/share/doc/skarabox/installation.html#b-beacon"
-    e "> Or read online at https://installer.skarabox.com/installation.html#b-beacon for remaining steps."
-    e ""
-    e "> Some options in the generated nix files must be tweaked."
-    e "> Please read the comments in 'flake.nix' and './$hostname/configuration.nix'."
+        e "Generating data pool passphrase in $secrets under $hostname/disks/dataPassphrase"
+        sops set "$secrets" \
+          "['$hostname']['disks']['dataPassphrase']" \
+          "\"$(openssl rand -hex 64)\""
+
+        sops unset "$secrets" \
+          "['tmp_secret']"
+
+        e ""
+        e "READ THIS"
+        e ""
+        e "> You are now at step B of the installation process."
+        e ""
+        e "> For the remaining steps, either build the manual locally:"
+        e ">   nix build .#manualHtml"
+        e "> Then open the file ./result/share/doc/skarabox/installation.html#b-beacon"
+        e "> Or read online at https://installer.skarabox.com/installation.html#b-beacon for remaining steps."
+        e ""
+        e "> Some options in the generated nix files must be tweaked."
+        e "> Please read the comments in 'flake.nix' and './$hostname/configuration.nix'."
   '';
 
 }

--- a/lib/get-facter.nix
+++ b/lib/get-facter.nix
@@ -6,7 +6,7 @@
 pkgs.writeShellApplication {
   name = "get-facter";
 
-  runtimeInputs  = [
+  runtimeInputs = [
     ssh-beacon
   ];
 

--- a/lib/sops-create-main-key.nix
+++ b/lib/sops-create-main-key.nix
@@ -1,5 +1,5 @@
 {
-  pkgs
+  pkgs,
 }:
 pkgs.writeShellApplication {
   name = "sops-create-main-key";

--- a/lib/ssh.nix
+++ b/lib/ssh.nix
@@ -1,5 +1,5 @@
 {
-  pkgs
+  pkgs,
 }:
 # SSH into a host
 #

--- a/modules/beacon.nix
+++ b/modules/beacon.nix
@@ -1,59 +1,70 @@
-{ config, lib, pkgs, ... }: let
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
   inherit (lib) mkForce types;
 
   cfg = config.skarabox;
 
   helptext = ''
-  * Step 1.  Enable network access to this server.
+    * Step 1.  Enable network access to this server.
 
-  For a wired network connection, just plug in an ethernet cable from your router
-  to this server. The connection will be made automatically.
+    For a wired network connection, just plug in an ethernet cable from your router
+    to this server. The connection will be made automatically.
 
-  For a wireless connection, if a card is found, a "Skarabox" wifi hotspot will
-  be created automatically. Connect to it from your laptop.
+    For a wireless connection, if a card is found, a "Skarabox" wifi hotspot will
+    be created automatically. Connect to it from your laptop.
   ''
-  + (if (cfg.staticNetwork == null) then ''
-  The IP address for this beacon is set through DHCP.
-  Run "ip a" command to get the IP address.
-  '' else ''
-  The IP address for this beacon is ${cfg.staticNetwork.ip}.
-  '')
+  + (
+    if (cfg.staticNetwork == null) then
+      ''
+        The IP address for this beacon is set through DHCP.
+        Run "ip a" command to get the IP address.
+      ''
+    else
+      ''
+        The IP address for this beacon is ${cfg.staticNetwork.ip}.
+      ''
+  )
   + ''
-  * Step 2.  Identify the disk layout.
+    * Step 2.  Identify the disk layout.
 
-  To know what disk existing in the system, type the command "lsblk" without
-  the double quotes. This will show lines like so:
+    To know what disk existing in the system, type the command "lsblk" without
+    the double quotes. This will show lines like so:
 
-  NAME             TYPE
-  /dev/nvme0n1     disk             This is an NVMe drive
-  /dev/sda         disk             This is an SSD or HDD drive
-  /dev/sdb         disK             This is an SSD or HDD drive
+    NAME             TYPE
+    /dev/nvme0n1     disk             This is an NVMe drive
+    /dev/sda         disk             This is an SSD or HDD drive
+    /dev/sdb         disK             This is an SSD or HDD drive
 
-  With the above setup, in the flake.nix template, set the following options:
+    With the above setup, in the flake.nix template, set the following options:
 
-      skarabox.disks.rootPool.disk1 = "/dev/nvme0n1"
-      skarabox.disks.dataPool.disk1 = "/dev/sda"
-      skarabox.disks.dataPool.disk2 = "/dev/sdb"
+        skarabox.disks.rootPool.disk1 = "/dev/nvme0n1"
+        skarabox.disks.dataPool.disk1 = "/dev/sda"
+        skarabox.disks.dataPool.disk2 = "/dev/sdb"
 
-  * Step 3.  Run the installer.
+    * Step 3.  Run the installer.
 
-  From your laptop, run the installer. The server will then reboot automatically
-  in the new system as soon as the installer ran successfully.
+    From your laptop, run the installer. The server will then reboot automatically
+    in the new system as soon as the installer ran successfully.
 
-  Enjoy your NixOS system powered by Skarabox!
+    Enjoy your NixOS system powered by Skarabox!
   '';
 
   readAndTrim = f: lib.strings.trim (builtins.readFile f);
   readAsStr = v: if lib.isPath v then readAndTrim v else v;
   readAsListOfStr = v: if lib.isList v then map readAsStr v else [ (readAsStr v) ];
-in {
+in
+{
   imports = [
     ./hotspot.nix
     ./network.nix
-    (lib.mkChangedOptionModule
-      [ "skarabox" "sshAuthorizedKey" ]
-      [ "skarabox" "sshAuthorizedKeys" ]
-      (config: readAsListOfStr config.skarabox.sshAuthorizedKey))
+    (lib.mkChangedOptionModule [ "skarabox" "sshAuthorizedKey" ] [ "skarabox" "sshAuthorizedKeys" ] (
+      config: readAsListOfStr config.skarabox.sshAuthorizedKey
+    ))
   ];
 
   options.skarabox = {
@@ -139,7 +150,11 @@ in {
     # Override user set in profiles/installation-device.nix
     users.users.${cfg.username} = {
       isNormalUser = true;
-      extraGroups = [ "wheel" "networkmanager" "video" ];
+      extraGroups = [
+        "wheel"
+        "networkmanager"
+        "video"
+      ];
       # Allow the graphical user to login without password
       initialHashedPassword = "";
       # Set shared ssh key
@@ -148,7 +163,10 @@ in {
     # Automatically log in at the virtual consoles.
     services.getty.autologinUser = lib.mkForce cfg.username;
     nix.settings.trusted-users = [ cfg.username ];
-    nix.settings.experimental-features = [ "nix-command" "flakes" ];
+    nix.settings.experimental-features = [
+      "nix-command"
+      "flakes"
+    ];
 
     image.fileName = mkForce "beacon.iso";
     image.baseName = mkForce "beacon";
@@ -157,24 +175,26 @@ in {
 
     boot.initrd.systemd.enable = true;
 
-    environment.systemPackages = let
-      skarabox-help = pkgs.writeText "skarabox-help" helptext;
-    in [
-      (pkgs.writeShellScriptBin "skarabox-help" ''
-       cat ${skarabox-help}
-       '')
-      pkgs.nixos-facter
+    environment.systemPackages =
+      let
+        skarabox-help = pkgs.writeText "skarabox-help" helptext;
+      in
+      [
+        (pkgs.writeShellScriptBin "skarabox-help" ''
+          cat ${skarabox-help}
+        '')
+        pkgs.nixos-facter
 
-      pkgs.tmux
+        pkgs.tmux
 
-      # Useful network tools
-      pkgs.dig
+        # Useful network tools
+        pkgs.dig
 
-      # Useful system tools
-      pkgs.htop
-      pkgs.glances
-      pkgs.iotop
-    ];
+        # Useful system tools
+        pkgs.htop
+        pkgs.glances
+        pkgs.iotop
+      ];
 
     services.openssh = {
       enable = true;
@@ -212,22 +232,26 @@ in {
 
     '');
 
-    environment.shellInit =
-      ''
+    environment.shellInit = ''
       message() {
-      ''
-      + (if (cfg.staticNetwork == null) then ''
-      echo -e "The IP address for this beacon is set through DHCP. It is printed hereunder:\n"
+    ''
+    + (
+      if (cfg.staticNetwork == null) then
+        ''
+          echo -e "The IP address for this beacon is set through DHCP. It is printed hereunder:\n"
 
-      echo "$ ip -oneline address"
-      ip -oneline address
-      echo
+          echo "$ ip -oneline address"
+          ip -oneline address
+          echo
 
-      '' else ''
-      echo -e "The IP address for this beacon is ${cfg.staticNetwork.ip}.\n"
+        ''
+      else
+        ''
+          echo -e "The IP address for this beacon is ${cfg.staticNetwork.ip}.\n"
 
-      '')
-      + ''
+        ''
+    )
+    + ''
       echo -e "The ssh server is listening on port ${toString cfg.sshPort}.\n"
 
       echo -e "This beacon's host key is (it will change after a reboot):\n"
@@ -239,6 +263,6 @@ in {
       if [[ -n "$XDG_VTNR" ]]; then
         message
       fi
-      '';
+    '';
   };
 }

--- a/modules/bootssh.nix
+++ b/modules/bootssh.nix
@@ -1,8 +1,18 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   cfg = config.skarabox.boot;
 
-  inherit (lib) getExe mkOption optionals types;
+  inherit (lib)
+    getExe
+    mkOption
+    optionals
+    types
+    ;
 
   replyPassword = "${config.boot.initrd.systemd.package}/lib/systemd/systemd-reply-password";
 
@@ -90,24 +100,30 @@ in
     # Keep this in sync with the stage-2 networkd config in ./network.nix.
     boot.initrd.systemd.network = {
       enable = true;
-    } // (if config.skarabox.staticNetwork == null then {
-      networks."10-lan" = {
-        matchConfig.Name = "en*";
-        networkConfig.DHCP = "ipv4";
-        linkConfig.RequiredForOnline = true;
-      };
-    } else {
-      networks."10-lan" = {
-        matchConfig.Name = "en*";
-        address = [
-          "${config.skarabox.staticNetwork.ip}/24"
-        ];
-        routes = [
-          { Gateway = config.skarabox.staticNetwork.gateway; }
-        ];
-        linkConfig.RequiredForOnline = true;
-      };
-    });
+    }
+    // (
+      if config.skarabox.staticNetwork == null then
+        {
+          networks."10-lan" = {
+            matchConfig.Name = "en*";
+            networkConfig.DHCP = "ipv4";
+            linkConfig.RequiredForOnline = true;
+          };
+        }
+      else
+        {
+          networks."10-lan" = {
+            matchConfig.Name = "en*";
+            address = [
+              "${config.skarabox.staticNetwork.ip}/24"
+            ];
+            routes = [
+              { Gateway = config.skarabox.staticNetwork.gateway; }
+            ];
+            linkConfig.RequiredForOnline = true;
+          };
+        }
+    );
 
     boot.initrd.systemd.storePaths = [
       unlockRoot
@@ -122,9 +138,14 @@ in
         # To prevent ssh clients from freaking out because a different host key is used,
         # a different port for ssh is used.
         port = lib.mkDefault cfg.sshPort;
-        hostKeys = lib.mkForce ([ "/boot/host_key" ] ++ (optionals (config.skarabox.disks.rootPool.disk2 != null) [ "/boot-backup/host_key" ]));
+        hostKeys = lib.mkForce (
+          [ "/boot/host_key" ]
+          ++ (optionals (config.skarabox.disks.rootPool.disk2 != null) [ "/boot-backup/host_key" ])
+        );
         # Only allow remote unlocks, not arbitrary initrd commands.
-        authorizedKeys = map (key: ''command="${getExe unlockRoot}" ${key}'') config.skarabox.sshAuthorizedKeys;
+        authorizedKeys = map (
+          key: ''command="${getExe unlockRoot}" ${key}''
+        ) config.skarabox.sshAuthorizedKeys;
       };
     };
   };

--- a/modules/configuration.nix
+++ b/modules/configuration.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   cfg = config.skarabox;
 in
@@ -9,7 +14,9 @@ in
   ];
 
   config = {
-    hardware.facter.reportPath = lib.mkIf (builtins.pathExists cfg.facter-config && (builtins.readFile cfg.facter-config != "")) cfg.facter-config;
+    hardware.facter.reportPath = lib.mkIf (
+      builtins.pathExists cfg.facter-config && (builtins.readFile cfg.facter-config != "")
+    ) cfg.facter-config;
 
     networking.hostName = cfg.hostname;
     networking.hostId = cfg.hostId;
@@ -19,7 +26,10 @@ in
     powerManagement.cpuFreqGovernor = "performance";
 
     nix.settings.trusted-users = [ cfg.username ];
-    nix.settings.experimental-features = [ "nix-command" "flakes" ];
+    nix.settings.experimental-features = [
+      "nix-command"
+      "flakes"
+    ];
     nix.settings.auto-optimise-store = true;
     nix.gc = {
       automatic = true;
@@ -29,10 +39,10 @@ in
 
     # See https://www.freedesktop.org/software/systemd/man/journald.conf.html#SystemMaxUse=
     services.journald.extraConfig = ''
-    SystemMaxUse=2G
-    SystemKeepFree=4G
-    SystemMaxFileSize=100M
-    MaxFileSec=1d
+      SystemMaxUse=2G
+      SystemKeepFree=4G
+      SystemMaxFileSize=100M
+      MaxFileSec=1d
     '';
 
     # hashedPasswordFile only works if users are not mutable.
@@ -45,9 +55,11 @@ in
     };
 
     security.sudo.extraRules = [
-      { users = [ cfg.username ];
+      {
+        users = [ cfg.username ];
         commands = [
-          { command = "ALL";
+          {
+            command = "ALL";
             options = [ "NOPASSWD" ];
           }
         ];
@@ -70,7 +82,7 @@ in
       };
       ports = [ cfg.sshPort ];
       openFirewall = true;
-      hostKeys = lib.mkForce [];
+      hostKeys = lib.mkForce [ ];
       generateHostKeys = false;
       extraConfig = ''
         HostKey /boot/host_key

--- a/modules/disks.nix
+++ b/modules/disks.nix
@@ -2,105 +2,118 @@
 let
   cfg = config.skarabox.disks;
 
-  inherit (lib) mkIf mkOption optionals optionalString types;
+  inherit (lib)
+    mkIf
+    mkOption
+    optionals
+    optionalString
+    types
+    ;
 in
 {
   options.skarabox.disks = {
     rootPool = mkOption {
       description = "ZFS root pool where the OS is stored.";
-      type = with types; submodule {
-        options = {
-          name = mkOption {
-            type = types.str;
-            description = "Name of the root pool";
-            default = "root";
-          };
+      type =
+        with types;
+        submodule {
+          options = {
+            name = mkOption {
+              type = types.str;
+              description = "Name of the root pool";
+              default = "root";
+            };
 
-          disk1 = mkOption {
-            type = types.str;
-            description = "SSD disk on which to install. Required";
-            example = "/dev/nvme0n1";
-          };
+            disk1 = mkOption {
+              type = types.str;
+              description = "SSD disk on which to install. Required";
+              example = "/dev/nvme0n1";
+            };
 
-          disk2 = mkOption {
-            type = types.nullOr types.str;
-            description = "Mirror SSD disk on which to install. Optional. Boot partition will be mirrored too.";
-            example = "/dev/nvme0n2";
-            default = null;
-          };
+            disk2 = mkOption {
+              type = types.nullOr types.str;
+              description = "Mirror SSD disk on which to install. Optional. Boot partition will be mirrored too.";
+              example = "/dev/nvme0n2";
+              default = null;
+            };
 
-          reservation = mkOption {
-            type = types.str;
-            description = ''
-              Disk size to reserve for ZFS internals. Should be between 10% and 15% of available size as recorded by zpool.
+            reservation = mkOption {
+              type = types.str;
+              description = ''
+                Disk size to reserve for ZFS internals. Should be between 10% and 15% of available size as recorded by zpool.
 
-              To get available size on zpool:
+                To get available size on zpool:
 
-                 zfs get -Hpo value available <pool name>
+                   zfs get -Hpo value available <pool name>
 
-              Then to set manually, if needed:
+                Then to set manually, if needed:
 
-                 sudo zfs set reservation=100G <pool name>
-            '';
-            example = "100G";
-          };
+                   sudo zfs set reservation=100G <pool name>
+              '';
+              example = "100G";
+            };
 
-          bootloader = mkOption {
-            type = types.enum [ "uefi" "bios" ];
-            description = ''
-              What bootloader mode to use.
-            '';
-            default = if config.hardware.facter.detected.uefi.supported then "uefi" else "bios";
-            defaultText = ''if config.hardware.facter.detected.uefi.supported then "uefi" else "bios"'';
-            example = "bios";
+            bootloader = mkOption {
+              type = types.enum [
+                "uefi"
+                "bios"
+              ];
+              description = ''
+                What bootloader mode to use.
+              '';
+              default = if config.hardware.facter.detected.uefi.supported then "uefi" else "bios";
+              defaultText = ''if config.hardware.facter.detected.uefi.supported then "uefi" else "bios"'';
+              example = "bios";
+            };
           };
         };
-      };
     };
 
     dataPool = mkOption {
       description = "ZFS pool to store important data.";
-      type = with types; submodule {
-        options = {
-          enable = lib.mkEnableOption "the data pool on other hard drives." // {
-            default = true;
-          };
+      type =
+        with types;
+        submodule {
+          options = {
+            enable = lib.mkEnableOption "the data pool on other hard drives." // {
+              default = true;
+            };
 
-          name = mkOption {
-            type = types.str;
-            description = "Name of the data pool";
-            default = "zdata";
-          };
+            name = mkOption {
+              type = types.str;
+              description = "Name of the data pool";
+              default = "zdata";
+            };
 
-          disk1 = mkOption {
-            type = types.str;
-            description = "First disk on which to install the data pool.";
-            example = "/dev/sda";
-          };
+            disk1 = mkOption {
+              type = types.str;
+              description = "First disk on which to install the data pool.";
+              example = "/dev/sda";
+            };
 
-          disk2 = mkOption {
-            type = types.str;
-            description = "Second disk on which to install the data pool.";
-            example = "/dev/sdb";
-          };
+            disk2 = mkOption {
+              type = types.str;
+              description = "Second disk on which to install the data pool.";
+              example = "/dev/sdb";
+            };
 
-          reservation = mkOption {
-            type = types.str;
-            description = ''
-              Disk size to reserve for ZFS internals. Should be between 5% and 10% of available size as recorded by zpool.
+            reservation = mkOption {
+              type = types.str;
+              description = ''
+                Disk size to reserve for ZFS internals. Should be between 5% and 10% of available size as recorded by zpool.
 
-              To get available size on zpool:
+                To get available size on zpool:
 
-                 zfs get -Hpo value available <pool name>
+                   zfs get -Hpo value available <pool name>
 
-              Then to set manually, if needed:
+                Then to set manually, if needed:
 
-                 sudo zfs set reservation=100G <pool name>
-            '';
-            example = "1T";
+                   sudo zfs set reservation=100G <pool name>
+              '';
+              example = "1T";
+            };
           };
         };
-      };
     };
 
     initialBackupDataset = mkOption {
@@ -109,78 +122,87 @@ in
       default = true;
     };
 
+  };
 
-
- };
-
- config = {
+  config = {
     disko.devices = {
-      disk = let
-        hasRaid = cfg.rootPool.disk2 != null;
+      disk =
+        let
+          hasRaid = cfg.rootPool.disk2 != null;
 
-        mkRoot = { disk, id ? "" }: {
-          type = "disk";
-          device = disk;
-          content = {
-            type = "gpt";
-            partitions = {
-              zfs = {
-                size = "100%";
-                content = {
-                  type = "zfs";
-                  pool = cfg.rootPool.name;
-                };
-              };
-              ESP = {
-                size = "500M";
-                type = "EF00";
-                content = {
-                  type = "filesystem";
-                  format = "vfat";
-                  mountpoint = "/boot${id}";
-                  # Otherwise you get https://discourse.nixos.org/t/security-warning-when-installing-nixos-23-11/37636/2
-                  mountOptions = [ "umask=0077" ];
-                  # Copy the host_key needed for initrd in a location accessible on boot.
-                  # It's prefixed by /mnt because we're installing and everything is mounted under /mnt.
-                  # We're using the same host key because, well, it's the same host!
-                  postMountHook = ''
-                    cp /tmp/host_key /mnt/boot${id}/host_key
-                  '';
-                };
-              };
-            } // lib.optionalAttrs (cfg.rootPool.bootloader == "bios") {
-              boot = {
-                size = "1M";
-                type = "EF02";
-                attributes = [ 0 ];
-              };
-            };
-          };
-        };
-
-        mkDataDisk = dataDisk: {
-          type = "disk";
-          device = dataDisk;
-          content = {
-            type = "gpt";
-            partitions = {
-              zfs = {
-                size = "100%";
-                content = {
-                  type = "zfs";
-                  pool = cfg.dataPool.name;
+          mkRoot =
+            {
+              disk,
+              id ? "",
+            }:
+            {
+              type = "disk";
+              device = disk;
+              content = {
+                type = "gpt";
+                partitions = {
+                  zfs = {
+                    size = "100%";
+                    content = {
+                      type = "zfs";
+                      pool = cfg.rootPool.name;
+                    };
+                  };
+                  ESP = {
+                    size = "500M";
+                    type = "EF00";
+                    content = {
+                      type = "filesystem";
+                      format = "vfat";
+                      mountpoint = "/boot${id}";
+                      # Otherwise you get https://discourse.nixos.org/t/security-warning-when-installing-nixos-23-11/37636/2
+                      mountOptions = [ "umask=0077" ];
+                      # Copy the host_key needed for initrd in a location accessible on boot.
+                      # It's prefixed by /mnt because we're installing and everything is mounted under /mnt.
+                      # We're using the same host key because, well, it's the same host!
+                      postMountHook = ''
+                        cp /tmp/host_key /mnt/boot${id}/host_key
+                      '';
+                    };
+                  };
+                }
+                // lib.optionalAttrs (cfg.rootPool.bootloader == "bios") {
+                  boot = {
+                    size = "1M";
+                    type = "EF02";
+                    attributes = [ 0 ];
+                  };
                 };
               };
             };
+
+          mkDataDisk = dataDisk: {
+            type = "disk";
+            device = dataDisk;
+            content = {
+              type = "gpt";
+              partitions = {
+                zfs = {
+                  size = "100%";
+                  content = {
+                    type = "zfs";
+                    pool = cfg.dataPool.name;
+                  };
+                };
+              };
+            };
           };
+        in
+        {
+          root = mkRoot { disk = cfg.rootPool.disk1; };
+          # Second root must have id=-backup.
+          root1 = mkIf hasRaid (mkRoot {
+            disk = cfg.rootPool.disk2;
+            id = "-backup";
+          });
+          data1 = mkIf cfg.dataPool.enable (mkDataDisk cfg.dataPool.disk1);
+          data2 = mkIf cfg.dataPool.enable (mkDataDisk cfg.dataPool.disk2);
         };
-      in {
-        root = mkRoot { disk = cfg.rootPool.disk1; };
-        # Second root must have id=-backup.
-        root1 = mkIf hasRaid (mkRoot { disk = cfg.rootPool.disk2; id = "-backup"; });
-        data1 = mkIf cfg.dataPool.enable (mkDataDisk cfg.dataPool.disk1);
-        data2 = mkIf cfg.dataPool.enable (mkDataDisk cfg.dataPool.disk2);
-      };
       zpool = {
         ${cfg.rootPool.name} = {
           type = "zpool";
@@ -322,7 +344,8 @@ in
               };
               type = "zfs_fs";
             };
-          } // lib.optionalAttrs cfg.initialBackupDataset {
+          }
+          // lib.optionalAttrs cfg.initialBackupDataset {
             "backup" = {
               type = "zfs_fs";
               mountpoint = "/srv/backup";
@@ -396,25 +419,30 @@ in
 
     # Setup Grub to support UEFI.
     # nodev is for UEFI.
-    boot.loader.grub = let
-      isUEFI = cfg.rootPool.bootloader == "uefi";
-    in {
-      enable = true;
-      efiSupport = isUEFI;
-      efiInstallAsRemovable = isUEFI;
+    boot.loader.grub =
+      let
+        isUEFI = cfg.rootPool.bootloader == "uefi";
+      in
+      {
+        enable = true;
+        efiSupport = isUEFI;
+        efiInstallAsRemovable = isUEFI;
 
-      mirroredBoots = lib.mkForce ([
-        {
-          path = "/boot";
-          devices = if isUEFI then [ "nodev" ] else [ cfg.rootPool.disk1 ];
-        }
-      ] ++ (optionals (cfg.rootPool.disk2 != null) [
-        {
-          path = "/boot-backup";
-          devices = if isUEFI then [ "nodev" ] else [ cfg.rootPool.disk2 ];
-        }
-      ]));
-    };
+        mirroredBoots = lib.mkForce (
+          [
+            {
+              path = "/boot";
+              devices = if isUEFI then [ "nodev" ] else [ cfg.rootPool.disk1 ];
+            }
+          ]
+          ++ (optionals (cfg.rootPool.disk2 != null) [
+            {
+              path = "/boot-backup";
+              devices = if isUEFI then [ "nodev" ] else [ cfg.rootPool.disk2 ];
+            }
+          ])
+        );
+      };
 
     services.zfs.autoScrub.enable = true;
   };

--- a/modules/hotspot.nix
+++ b/modules/hotspot.nix
@@ -1,4 +1,9 @@
-{ config, pkgs, lib, ... }:
+{
+  config,
+  pkgs,
+  lib,
+  ...
+}:
 let
   cfg = config.skarabox.hotspot;
 
@@ -27,7 +32,10 @@ in
   config = lib.mkIf cfg.enable {
     systemd.services."${hotspotService}@" = {
       description = "Create AP Service";
-      after = [ "network.target" "network-pre.target" ];
+      after = [
+        "network.target"
+        "network-pre.target"
+      ];
       serviceConfig = {
         ExecStart = "${pkgs.linux-wifi-hotspot}/bin/create_ap --redirect-to-localhost -n -g ${cfg.ip} %I ${cfg.ssid}";
         KillSignal = "SIGINT";
@@ -37,7 +45,10 @@ in
 
     systemd.services."skarabox-hotspot-force-udev" = {
       description = "Trigger udev for existing wlan interfaces";
-      after = [ "systemd-udev-settle.service" "network-pre.target" ];
+      after = [
+        "systemd-udev-settle.service"
+        "network-pre.target"
+      ];
       before = [ "network.target" ];
       wantedBy = [ "network.target" ];
 

--- a/modules/network.nix
+++ b/modules/network.nix
@@ -10,64 +10,81 @@ in
       description = "Use static IP configuration. If unset, use DHCP.";
       default = null;
       example = lib.literalExpression ''
-      {
-        ip = "192.168.1.30";
-        gateway = "192.168.1.1";
-      }
+        {
+          ip = "192.168.1.30";
+          gateway = "192.168.1.1";
+        }
       '';
-      type = types.nullOr (types.submodule {
-        options = {
-          enable = lib.mkEnableOption "Skarabox static IP configuration";
-          ip = mkOption {
-            type = types.str;
-            description = "Static IP to use.";
-          };
-          gateway = mkOption {
-            type = types.str;
-            description = "IP Gateway, often same beginning as `ip` and finishing by a `1`: `XXX.YYY.ZZZ.1`.";
-          };
-          device = mkOption {
-            description = ''
-            Device for which to configure the IP address for.
+      type = types.nullOr (
+        types.submodule {
+          options = {
+            enable = lib.mkEnableOption "Skarabox static IP configuration";
+            ip = mkOption {
+              type = types.str;
+              description = "Static IP to use.";
+            };
+            gateway = mkOption {
+              type = types.str;
+              description = "IP Gateway, often same beginning as `ip` and finishing by a `1`: `XXX.YYY.ZZZ.1`.";
+            };
+            device = mkOption {
+              description = ''
+                Device for which to configure the IP address for.
 
-            Either pass the device name directly if you know it, like "ens3".
-            Or configure the `deviceName` option to get the first device name
-            matching that prefix from the facter.json report.
-            '';
-            default = { namePrefix = "en"; };
-            type = with types; oneOf [
-              str
-              (submodule {
-                options = {
-                  namePrefix = mkOption {
-                    type = str;
-                    description = "Name prefix as it appears in the facter.json report. Used to distinguish between wifi and ethernet.";
-                    default = "en";
-                    example = "wl";
-                  };
-                };
-              })
-            ];
-          };
-          deviceName = mkOption {
-            description = ''
-            Result of applying match pattern from `.device` option
-            or the string defined in `.device` option.
-            '';
-            readOnly = true;
-            internal = true;
-            default = let
-              cfg' = cfg.staticNetwork;
+                Either pass the device name directly if you know it, like "ens3".
+                Or configure the `deviceName` option to get the first device name
+                matching that prefix from the facter.json report.
+              '';
+              default = {
+                namePrefix = "en";
+              };
+              type =
+                with types;
+                oneOf [
+                  str
+                  (submodule {
+                    options = {
+                      namePrefix = mkOption {
+                        type = str;
+                        description = "Name prefix as it appears in the facter.json report. Used to distinguish between wifi and ethernet.";
+                        default = "en";
+                        example = "wl";
+                      };
+                    };
+                  })
+                ];
+            };
+            deviceName = mkOption {
+              description = ''
+                Result of applying match pattern from `.device` option
+                or the string defined in `.device` option.
+              '';
+              readOnly = true;
+              internal = true;
+              default =
+                let
+                  cfg' = cfg.staticNetwork;
 
-              network_interfaces = if builtins.hasAttr "hardware" config.hardware.facter.report then config.hardware.facter.report.hardware.network_interface else [];
+                  network_interfaces =
+                    if builtins.hasAttr "hardware" config.hardware.facter.report then
+                      config.hardware.facter.report.hardware.network_interface
+                    else
+                      [ ];
 
-              firstMatchingDevice = if network_interfaces == [] then "" else builtins.head (builtins.filter (lib.hasPrefix "en") (lib.flatten (map (x: x.unix_device_names) network_interfaces)));
-            in
-              # hardware attr is not set when using system.build.noFacter.
-              if isString cfg'.device then cfg'.device else firstMatchingDevice;
+                  firstMatchingDevice =
+                    if network_interfaces == [ ] then
+                      ""
+                    else
+                      builtins.head (
+                        builtins.filter (lib.hasPrefix "en") (lib.flatten (map (x: x.unix_device_names) network_interfaces))
+                      );
+                in
+                # hardware attr is not set when using system.build.noFacter.
+                if isString cfg'.device then cfg'.device else firstMatchingDevice;
+            };
           };
-        };
-      });
+        }
+      );
     };
 
     disableNetworkSetup = mkOption {
@@ -84,7 +101,10 @@ in
   config = lib.mkIf (!cfg.disableNetworkSetup) {
     assertions = [
       {
-        assertion = !config.boot.initrd.network.ssh.enable || cfg.staticNetwork != null || config.boot.initrd.systemd.network.enable;
+        assertion =
+          !config.boot.initrd.network.ssh.enable
+          || cfg.staticNetwork != null
+          || config.boot.initrd.systemd.network.enable;
         message = ''
           Initrd SSH is enabled, but no static IP is set and initrd systemd networking is disabled. The box will not be reachable through the network on boot and you will not be able to enter the passphrase through SSH.
 
@@ -101,24 +121,30 @@ in
       {
         enable = true;
       }
-      // (if cfg.staticNetwork == null then {
-        networks."10-lan" = {
-          matchConfig.Name = "en*";
-          networkConfig.DHCP = "ipv4";
-          linkConfig.RequiredForOnline = true;
-        };
-      } else {
-        networks."10-lan" = {
-          matchConfig.Name = "en*";
-          address = [
-            "${cfg.staticNetwork.ip}/24"
-          ];
-          routes = [
-            { Gateway = cfg.staticNetwork.gateway; }
-          ];
-          linkConfig.RequiredForOnline = true;
-        };
-      }));
+      // (
+        if cfg.staticNetwork == null then
+          {
+            networks."10-lan" = {
+              matchConfig.Name = "en*";
+              networkConfig.DHCP = "ipv4";
+              linkConfig.RequiredForOnline = true;
+            };
+          }
+        else
+          {
+            networks."10-lan" = {
+              matchConfig.Name = "en*";
+              address = [
+                "${cfg.staticNetwork.ip}/24"
+              ];
+              routes = [
+                { Gateway = cfg.staticNetwork.gateway; }
+              ];
+              linkConfig.RequiredForOnline = true;
+            };
+          }
+      )
+    );
 
   };
 }

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -3,7 +3,8 @@ let
   inherit (lib) mkOption types;
 
   isNonEmptySingleLine = v: v != "" && !(lib.hasInfix "\n" v);
-  isNonEmptySingleLineFile = v:
+  isNonEmptySingleLineFile =
+    v:
     let
       lines = lib.splitString "\n" (builtins.readFile v);
     in
@@ -14,10 +15,9 @@ let
 in
 {
   imports = [
-    (lib.mkChangedOptionModule
-      [ "skarabox" "sshAuthorizedKey" ]
-      [ "skarabox" "sshAuthorizedKeys" ]
-      (config: readAsListOfStr config.skarabox.sshAuthorizedKey))
+    (lib.mkChangedOptionModule [ "skarabox" "sshAuthorizedKey" ] [ "skarabox" "sshAuthorizedKeys" ] (
+      config: readAsListOfStr config.skarabox.sshAuthorizedKey
+    ))
   ];
 
   options.skarabox = {

--- a/template/flake.nix
+++ b/template/flake.nix
@@ -19,90 +19,102 @@
     sops-nix.url = "github:Mic92/sops-nix";
   };
 
-  outputs = inputs@{ self, nixpkgs, flake-parts, ... }: flake-parts.lib.mkFlake { inherit inputs; } ({ config, ... }: {
-    systems = [
-      "x86_64-linux"
-      "aarch64-linux"
-      # Darwin systems are supported but not as hosts to deploy to.
-      "x86_64-darwin"
-      "aarch64-darwin"
-    ];
-
-    imports = [
-      inputs.skarabox.flakeModules.default
-      # Only one of deploy-rs or colmena is required to deploy.
-      # You can comment the one you don't use and remove the corresponding input.
-      inputs.skarabox.flakeModules.deploy-rs
-      inputs.skarabox.flakeModules.colmena
-    ];
-
-    skarabox.hosts = {
-      myskarabox = let
-        system = "x86_64-linux";
-      in {
-        # Comment this line to use inputs.nixpkgs as the input instead of SelfHostBlocks.
-        nixpkgs = inputs.selfhostblocks.lib.${system}.patchedNixpkgs;
-        inherit system;
-        hostKeyPath = "./myskarabox/host_key";
-        hostKeyPub = ./myskarabox/host_key.pub;
-        ip = "192.168.1.30";
-
-        # These ports default to the one set in ./myskarabox/configuration.nix
-        # You should only need to set these to other values
-        # if the target host is accessed through some proxy
-        # with some port forwarding.
-        #
-        # sshPort = 2222;
-        # sshBootPort = 2223;
-
-        # If you want to use an ssh agent to store the private key
-        # set the sshPrivateKeyPath option to `null`,
-        # generate an ssh key and add it to the ssh agent
-        # then replace the ssh.pub file with the public key from the ssh agent.
-        # Don't forget to set correct permissions on the ssh.pub file with
-        # chmod 600 ssh.pub
-        #
-        # sshPrivateKeyPath = "./myskarabox/ssh";
-        # sshPublicKeyPath = ./myskarabox/ssh.pub;
-
-        modules = [
-          inputs.selfhostblocks.nixosModules.default
-          inputs.sops-nix.nixosModules.default
-          self.nixosModules.myskarabox
+  outputs =
+    inputs@{
+      self,
+      nixpkgs,
+      flake-parts,
+      ...
+    }:
+    flake-parts.lib.mkFlake { inherit inputs; } (
+      { config, ... }:
+      {
+        systems = [
+          "x86_64-linux"
+          "aarch64-linux"
+          # Darwin systems are supported but not as hosts to deploy to.
+          "x86_64-darwin"
+          "aarch64-darwin"
         ];
 
-        # Set these options only if they differ from the options above.
-        # This is the case for example when installing on a cloud instance
-        # where the ssh config is given to you by the cloud provider.
-        beacon = {
-          # username = "<given by the cloud provider>";
-          # sshPort = <given by the cloud provider>;
-          # sshPrivateKeyPath = "<given by the cloud provider>";
-          # sshPublicKeyPath = "<given by the cloud provider>";
-        };
-        extraBeaconModules = [
-          {
-            # Add more utilities
-            #
-            # environment.systemPackages = [
-            #   pkgs.tmux
-            #   pkgs.htop
-            #   pkgs.glances
-            #   pkgs.iotop
-            # ];
-          }
+        imports = [
+          inputs.skarabox.flakeModules.default
+          # Only one of deploy-rs or colmena is required to deploy.
+          # You can comment the one you don't use and remove the corresponding input.
+          inputs.skarabox.flakeModules.deploy-rs
+          inputs.skarabox.flakeModules.colmena
         ];
-      };
-    };
 
-    flake = {
-      nixosModules = {
-        myskarabox = {
-          imports = [
-            ./myskarabox/configuration.nix
-          ];
+        skarabox.hosts = {
+          myskarabox =
+            let
+              system = "x86_64-linux";
+            in
+            {
+              # Comment this line to use inputs.nixpkgs as the input instead of SelfHostBlocks.
+              nixpkgs = inputs.selfhostblocks.lib.${system}.patchedNixpkgs;
+              inherit system;
+              hostKeyPath = "./myskarabox/host_key";
+              hostKeyPub = ./myskarabox/host_key.pub;
+              ip = "192.168.1.30";
+
+              # These ports default to the one set in ./myskarabox/configuration.nix
+              # You should only need to set these to other values
+              # if the target host is accessed through some proxy
+              # with some port forwarding.
+              #
+              # sshPort = 2222;
+              # sshBootPort = 2223;
+
+              # If you want to use an ssh agent to store the private key
+              # set the sshPrivateKeyPath option to `null`,
+              # generate an ssh key and add it to the ssh agent
+              # then replace the ssh.pub file with the public key from the ssh agent.
+              # Don't forget to set correct permissions on the ssh.pub file with
+              # chmod 600 ssh.pub
+              #
+              # sshPrivateKeyPath = "./myskarabox/ssh";
+              # sshPublicKeyPath = ./myskarabox/ssh.pub;
+
+              modules = [
+                inputs.selfhostblocks.nixosModules.default
+                inputs.sops-nix.nixosModules.default
+                self.nixosModules.myskarabox
+              ];
+
+              # Set these options only if they differ from the options above.
+              # This is the case for example when installing on a cloud instance
+              # where the ssh config is given to you by the cloud provider.
+              beacon = {
+                # username = "<given by the cloud provider>";
+                # sshPort = <given by the cloud provider>;
+                # sshPrivateKeyPath = "<given by the cloud provider>";
+                # sshPublicKeyPath = "<given by the cloud provider>";
+              };
+              extraBeaconModules = [
+                {
+                  # Add more utilities
+                  #
+                  # environment.systemPackages = [
+                  #   pkgs.tmux
+                  #   pkgs.htop
+                  #   pkgs.glances
+                  #   pkgs.iotop
+                  # ];
+                }
+              ];
+            };
         };
-      };
-    };
-  });
+
+        flake = {
+          nixosModules = {
+            myskarabox = {
+              imports = [
+                ./myskarabox/configuration.nix
+              ];
+            };
+          };
+        };
+      }
+    );
 }

--- a/template/myskarabox/configuration.nix
+++ b/template/myskarabox/configuration.nix
@@ -22,18 +22,18 @@ in
       skarabox.hashedPasswordFile = config.sops.secrets."myskarabox/user/hashedPassword".path;
       skarabox.facter-config = ./facter.json;
       skarabox.disks.rootPool = {
-        disk1 = "/dev/nvme0n1";  # Update with result of running `fdisk -l` on the beacon.
-        disk2 = null;  # Set a value only if you have a second disk for the root partition.
-        reservation = "500M";  # Set to 10% of size SSD.
+        disk1 = "/dev/nvme0n1"; # Update with result of running `fdisk -l` on the beacon.
+        disk2 = null; # Set a value only if you have a second disk for the root partition.
+        reservation = "500M"; # Set to 10% of size SSD.
         # The bootloader - "uefi" or "bios" - should be detected from the facter.json.
         # If the detected value is wrong, you can set it manually with the following option:
         # bootloader = "bios";
       };
       skarabox.disks.dataPool = {
-        enable = true;  # Disable if only an SSD for root is present.
-        disk1 = "/dev/sda";  # Update with result of running `fdisk -l` on the beacon.
-        disk2 = "/dev/sdb";  # Update with result of running `fdisk -l` on the beacon.
-        reservation = "10G";  # Set to 5% of size Hard Drives.
+        enable = true; # Disable if only an SSD for root is present.
+        disk1 = "/dev/sda"; # Update with result of running `fdisk -l` on the beacon.
+        disk2 = "/dev/sdb"; # Update with result of running `fdisk -l` on the beacon.
+        reservation = "10G"; # Set to 5% of size Hard Drives.
       };
       # For security by obscurity, we choose another ssh port here than the default 22.
       skarabox.boot.sshPort = 2223;

--- a/tests/default.nix
+++ b/tests/default.nix
@@ -1,4 +1,8 @@
-{ pkgs, system, nix-flake-tests }:
+{
+  pkgs,
+  system,
+  nix-flake-tests,
+}:
 let
   # It is necessary to add --allow-import-from-derivation explicitly because the flake show command
   # does not pick it up from the config, on purpose.
@@ -9,8 +13,14 @@ in
 {
   lib = nix-flake-tests.lib.check {
     inherit pkgs;
-    tests = pkgs.callPackage ./lib.nix {};
+    tests = pkgs.callPackage ./lib.nix { };
   };
 }
-// (import ./variants.nix { inherit system nix setsid; inherit (pkgs) gnugrep jq writeShellScriptBin; })
-// (import ./static.nix { inherit system nix setsid; inherit (pkgs) jq writeShellScriptBin; })
+// (import ./variants.nix {
+  inherit system nix setsid;
+  inherit (pkgs) gnugrep jq writeShellScriptBin;
+})
+// (import ./static.nix {
+  inherit system nix setsid;
+  inherit (pkgs) jq writeShellScriptBin;
+})

--- a/tests/lib.nix
+++ b/tests/lib.nix
@@ -3,40 +3,59 @@
   ...
 }:
 let
-  add-sops-cfg = pkgs.callPackage ../lib/add-sops-cfg.nix {};
+  add-sops-cfg = pkgs.callPackage ../lib/add-sops-cfg.nix { };
   singleKeyFile = ./fixtures/single-ssh-key.pub;
   singleKey = pkgs.lib.removeSuffix "\n" (builtins.readFile singleKeyFile);
   multiKeyFile = ./fixtures/two-ssh-keys.pub;
-  evalSshAuthorizedKey = sshAuthorizedKeys: (pkgs.lib.evalModules {
-    modules = [
-      (pkgs.path + "/nixos/modules/misc/assertions.nix")
-      ../modules/options.nix
-      ({ ... }: {
-        config.skarabox.sshAuthorizedKeys = sshAuthorizedKeys;
-      })
-    ];
-  }).config.skarabox.sshAuthorizedKeys;
-  tryEvalSshAuthorizedKey = sshAuthorizedKeys:
+  evalSshAuthorizedKey =
+    sshAuthorizedKeys:
+    (pkgs.lib.evalModules {
+      modules = [
+        (pkgs.path + "/nixos/modules/misc/assertions.nix")
+        ../modules/options.nix
+        (
+          { ... }:
+          {
+            config.skarabox.sshAuthorizedKeys = sshAuthorizedKeys;
+          }
+        )
+      ];
+    }).config.skarabox.sshAuthorizedKeys;
+  tryEvalSshAuthorizedKey =
+    sshAuthorizedKeys:
     let
       value = evalSshAuthorizedKey sshAuthorizedKeys;
     in
     builtins.tryEval (builtins.deepSeq value value);
 
-  exec = {
-    name,
-    cmd,
-    init ? ""
-  }: builtins.readFile ((pkgs.callPackage ({ runCommand }: runCommand name {
-    nativeBuildInputs = [
-      add-sops-cfg
-    ];
-  } (let
-    initFile = pkgs.writeText "init-sops" init;
-  in ''
-    mkdir $out
-    ${if init != "" then "cat ${initFile} > $out/.sops.yaml" else ""}
-    add-sops-cfg -o $out/.sops.yaml ${cmd}
-  '')) {}) + "/.sops.yaml");
+  exec =
+    {
+      name,
+      cmd,
+      init ? "",
+    }:
+    builtins.readFile (
+      (pkgs.callPackage (
+        { runCommand }:
+        runCommand name
+          {
+            nativeBuildInputs = [
+              add-sops-cfg
+            ];
+          }
+          (
+            let
+              initFile = pkgs.writeText "init-sops" init;
+            in
+            ''
+              mkdir $out
+              ${if init != "" then "cat ${initFile} > $out/.sops.yaml" else ""}
+              add-sops-cfg -o $out/.sops.yaml ${cmd}
+            ''
+          )
+      ) { })
+      + "/.sops.yaml"
+    );
 in
 {
   testAddSopsCfg_new_alias = {
@@ -141,7 +160,7 @@ in
         key_groups:
         - age:
           - *a
-      '';
+    '';
 
     expr = exec {
       name = "testAddSopsCfg_append";
@@ -153,7 +172,7 @@ in
           key_groups:
           - age:
             - *a
-        '';
+      '';
       cmd = "path-regex a b/b.yaml$";
     };
   };
@@ -162,14 +181,14 @@ in
     expected = ''
       keys:
       - &a OTHERSOPSKEY
-      '';
+    '';
 
     expr = exec {
       name = "testAddSopsCfg_replace";
       init = ''
         keys:
         - &a ASOPSKEY
-        '';
+      '';
       cmd = "alias a OTHERSOPSKEY";
     };
   };
@@ -188,7 +207,7 @@ in
         key_groups:
         - age:
           - *b
-      '';
+    '';
 
     expr = exec {
       name = "testAddSopsCfg_replace";
@@ -205,7 +224,7 @@ in
           key_groups:
           - age:
             - *b
-        '';
+      '';
       cmd = "alias a OTHERSOPSKEY";
     };
   };
@@ -240,95 +259,111 @@ in
     expr = evalSshAuthorizedKey [ singleKey ];
   };
 
-  testBootsshTrimsNewlineTerminatedAuthorizedKey = let
-    nixos = import (pkgs.path + "/nixos/lib/eval-config.nix") {
-      inherit (pkgs) system;
-      modules = [
-        ../modules/options.nix
-        ../modules/bootssh.nix
-        ({ lib, ... }: {
-          options.skarabox.staticNetwork = lib.mkOption {
-            type = with lib.types; nullOr attrs;
-            default = null;
-          };
+  testBootsshTrimsNewlineTerminatedAuthorizedKey =
+    let
+      nixos = import (pkgs.path + "/nixos/lib/eval-config.nix") {
+        inherit (pkgs) system;
+        modules = [
+          ../modules/options.nix
+          ../modules/bootssh.nix
+          (
+            { lib, ... }:
+            {
+              options.skarabox.staticNetwork = lib.mkOption {
+                type = with lib.types; nullOr attrs;
+                default = null;
+              };
 
-          options.skarabox.disks.rootPool.disk2 = lib.mkOption {
-            type = with lib.types; nullOr str;
-            default = null;
-          };
+              options.skarabox.disks.rootPool.disk2 = lib.mkOption {
+                type = with lib.types; nullOr str;
+                default = null;
+              };
 
-          config = {
-            skarabox.sshAuthorizedKey = singleKeyFile;
-            system.stateVersion = "26.11";
-          };
-        })
-      ];
+              config = {
+                skarabox.sshAuthorizedKey = singleKeyFile;
+                system.stateVersion = "26.11";
+              };
+            }
+          )
+        ];
+      };
+      authorizedKeys = nixos.config.boot.initrd.network.ssh.authorizedKeys;
+      authorizedKey = pkgs.lib.head authorizedKeys;
+      authorizedKeyMatch = builtins.match ''command="/nix/store/[a-z0-9]+-skarabox-unlock-root/bin/skarabox-unlock-root" (.*)'' authorizedKey;
+    in
+    {
+      expected = true;
+      expr = pkgs.lib.length authorizedKeys == 1 && authorizedKeyMatch == [ singleKey ];
     };
-    authorizedKeys = nixos.config.boot.initrd.network.ssh.authorizedKeys;
-    authorizedKey = pkgs.lib.head authorizedKeys;
-    authorizedKeyMatch = builtins.match ''command="/nix/store/[a-z0-9]+-skarabox-unlock-root/bin/skarabox-unlock-root" (.*)'' authorizedKey;
-  in {
-    expected = true;
-    expr =
-      pkgs.lib.length authorizedKeys == 1
-      && authorizedKeyMatch == [ singleKey ];
-  };
 
-  testMultiHostSameArch = let
-    # Create minimal test flake using the actual skarabox flakeModule
-    dummy = pkgs.writeText "dummy" "";
-    testFlake = import ../flakeModules/default.nix {
-      inherit (pkgs) lib;
-      config = {
-        skarabox.hosts = {
-          server1 = {
-            system = "aarch64-linux";
-            hostKeyPub = dummy;
-            sshAuthorizedKeys = [ dummy ];
-          };
-          server2 = {
-            system = "aarch64-linux";
-            hostKeyPub = dummy;
-            sshAuthorizedKeys = [ dummy ];
-          };
-          server3 = {
-            system = "x86_64-linux";
-            hostKeyPub = dummy;
-            sshAuthorizedKeys = [ dummy ];
+  testMultiHostSameArch =
+    let
+      # Create minimal test flake using the actual skarabox flakeModule
+      dummy = pkgs.writeText "dummy" "";
+      testFlake = import ../flakeModules/default.nix {
+        inherit (pkgs) lib;
+        config = {
+          skarabox.hosts = {
+            server1 = {
+              system = "aarch64-linux";
+              hostKeyPub = dummy;
+              sshAuthorizedKeys = [ dummy ];
+            };
+            server2 = {
+              system = "aarch64-linux";
+              hostKeyPub = dummy;
+              sshAuthorizedKeys = [ dummy ];
+            };
+            server3 = {
+              system = "x86_64-linux";
+              hostKeyPub = dummy;
+              sshAuthorizedKeys = [ dummy ];
+            };
           };
         };
+        inputs = {
+          skarabox.nixosModules.skarabox = { };
+        };
       };
-      inputs = {
-        skarabox.nixosModules.skarabox = {};
+
+      # Get the flake outputs
+      flakeOutputs = testFlake.config.flake { };
+
+      # Check nixosConfigurations (all three should be present)
+      configNames = builtins.sort builtins.lessThan (builtins.attrNames flakeOutputs.nixosConfigurations);
+
+      # Check packages for aarch64-linux (both aarch64 hosts should appear)
+      # Filter to just the base host packages (not the -debug-* variants)
+      aarch64Packages = builtins.sort builtins.lessThan (
+        builtins.filter (name: !(pkgs.lib.hasInfix "-debug-" name)) (
+          builtins.attrNames (flakeOutputs.packages."aarch64-linux" or { })
+        )
+      );
+
+      # Check packages for x86_64-linux (the x86_64 host should appear)
+      x86Packages = builtins.sort builtins.lessThan (
+        builtins.filter (name: !(pkgs.lib.hasInfix "-debug-" name)) (
+          builtins.attrNames (flakeOutputs.packages."x86_64-linux" or { })
+        )
+      );
+    in
+    {
+      expected = {
+        configs = [
+          "server1"
+          "server2"
+          "server3"
+        ];
+        aarch64Packages = [
+          "server1"
+          "server2"
+        ];
+        x86Packages = [ "server3" ];
+      };
+      expr = {
+        configs = configNames;
+        aarch64Packages = aarch64Packages;
+        x86Packages = x86Packages;
       };
     };
-
-    # Get the flake outputs
-    flakeOutputs = testFlake.config.flake {};
-
-    # Check nixosConfigurations (all three should be present)
-    configNames = builtins.sort builtins.lessThan (builtins.attrNames flakeOutputs.nixosConfigurations);
-
-    # Check packages for aarch64-linux (both aarch64 hosts should appear)
-    # Filter to just the base host packages (not the -debug-* variants)
-    aarch64Packages = builtins.sort builtins.lessThan
-      (builtins.filter (name: !(pkgs.lib.hasInfix "-debug-" name))
-        (builtins.attrNames (flakeOutputs.packages."aarch64-linux" or {})));
-
-    # Check packages for x86_64-linux (the x86_64 host should appear)
-    x86Packages = builtins.sort builtins.lessThan
-      (builtins.filter (name: !(pkgs.lib.hasInfix "-debug-" name))
-        (builtins.attrNames (flakeOutputs.packages."x86_64-linux" or {})));
-  in {
-    expected = {
-      configs = [ "server1" "server2" "server3" ];
-      aarch64Packages = [ "server1" "server2" ];
-      x86Packages = [ "server3" ];
-    };
-    expr = {
-      configs = configNames;
-      aarch64Packages = aarch64Packages;
-      x86Packages = x86Packages;
-    };
-  };
 }

--- a/tests/static.nix
+++ b/tests/static.nix
@@ -1,4 +1,10 @@
-{ system, nix, jq, setsid, writeShellScriptBin }:
+{
+  system,
+  nix,
+  jq,
+  setsid,
+  writeShellScriptBin,
+}:
 {
   staticIP = writeShellScriptBin "staticIP" ''
     set -e

--- a/tests/variants.nix
+++ b/tests/variants.nix
@@ -1,268 +1,277 @@
-{ system, nix, gnugrep, jq, setsid, writeShellScriptBin }:
+{
+  system,
+  nix,
+  gnugrep,
+  jq,
+  setsid,
+  writeShellScriptBin,
+}:
 let
   toBashBool = v: if v then "true" else "false";
 
-  templateTest = {
-    name,
-    rootDisk2,
-    dataPool,
-    sshPort ? 2222,
-    sshBootPort ? 2223,
-    legacyNixpkgs ? false,
-  }: writeShellScriptBin name ''
-    set -xe
+  templateTest =
+    {
+      name,
+      rootDisk2,
+      dataPool,
+      sshPort ? 2222,
+      sshBootPort ? 2223,
+      legacyNixpkgs ? false,
+    }:
+    writeShellScriptBin name ''
+      set -xe
 
-    e () {
-      echo -e "\e[1;31mSKARABOX-TEMPLATE:\e[0m \e[1;0m$@\e[0m"
-    }
+      e () {
+        echo -e "\e[1;31mSKARABOX-TEMPLATE:\e[0m \e[1;0m$@\e[0m"
+      }
 
-    group () {
-      if [ -z "$CI" ]; then
-        e "$@"
+      group () {
+        if [ -z "$CI" ]; then
+          e "$@"
+        else
+          echo "::group::$@"
+        fi
+      }
+
+      endgroup () {
+        if [ -z "$CI" ]; then
+          e "$@"
+        else
+          e "$@"
+          echo "::endgroup::"
+        fi
+      }
+
+      graphic=-nographic
+      tmpdir=
+      remove_tmpdir=false
+      beacon_vm_pid=
+      rootDisk2=${toBashBool rootDisk2}
+      dataPool=${toBashBool dataPool}
+      legacyNixpkgs=${toBashBool legacyNixpkgs}
+      sshPort=${toString sshPort}
+      sshBootPort=${toString sshBootPort}
+
+      cleanup () {
+        status="$1"
+        # Disable traps while cleaning up so cleanup does not recursively call itself.
+        trap - INT TERM EXIT
+
+        if [ -n "$beacon_vm_pid" ]; then
+          # A leading '-' makes kill signal that process group, not just that PID.
+          kill -- "-$beacon_vm_pid" 2>/dev/null || true
+          wait "$beacon_vm_pid" 2>/dev/null || true
+        fi
+
+        if [ "$remove_tmpdir" = true ]; then
+          rm -rf -- "$tmpdir"
+        fi
+
+        exit "$status"
+      }
+      # Preserve the original exit status, and use conventional statuses for signals.
+      trap 'cleanup $?' EXIT
+      trap 'cleanup 130' INT
+      trap 'cleanup 143' TERM
+
+      while getopts "gp:" o; do
+        case "''${o}" in
+          g)
+            graphic=
+            ;;
+          p)
+            tmpdir=''${OPTARG}
+            ;;
+          *)
+            echo "$0 [-p TEMPDIR] [-g]"
+            exit 1
+            ;;
+        esac
+      done
+      shift $((OPTIND-1))
+
+      if [ -z "$tmpdir" ]; then
+        group "Creating tmpdir"
+        tmpdir="$(mktemp -d)"
+        remove_tmpdir=true
+        e "Created temp dir at $tmpdir, will be cleaned up on exit or abort"
+        endgroup "Done creating tmpdir"
       else
-        echo "::group::$@"
+        e "Using provided temp dir $tmpdir, it will not be cleaned up"
       fi
-    }
+      cd "$tmpdir"
 
-    endgroup () {
-      if [ -z "$CI" ]; then
-        e "$@"
-      else
-        e "$@"
-        echo "::endgroup::"
+      group "Initialising template"
+      echo skarabox1234 | ${nix} run ${../.}#init -- -v -y -s
+      sed -i "s/\(ip =\) \"192.168.1.30\"/\1 \"127.0.0.1\"/" "flake.nix"
+      sed -i "s/\(system =\) \"x86_64-linux\"/\1 \"${system}\"/" "flake.nix"
+      if [ "$legacyNixpkgs" = true ]; then
+        sed -i "s/\(nixpkgs =\) .*;$/\1 null;/" "flake.nix"
+        sed -i "/inputs.selfhostblocks.nixosModules.default$/d" "flake.nix"
       fi
-    }
+      sed -i "s/\(skarabox.sshPort =\) 2222/\1 $sshPort/" "./myskarabox/configuration.nix"
+      sed -i "s/\(skarabox.boot.sshPort =\) 2223/\1 $sshBootPort/" "./myskarabox/configuration.nix"
 
-    graphic=-nographic
-    tmpdir=
-    remove_tmpdir=false
-    beacon_vm_pid=
-    rootDisk2=${toBashBool rootDisk2}
-    dataPool=${toBashBool dataPool}
-    legacyNixpkgs=${toBashBool legacyNixpkgs}
-    sshPort=${toString sshPort}
-    sshBootPort=${toString sshBootPort}
-
-    cleanup () {
-      status="$1"
-      # Disable traps while cleaning up so cleanup does not recursively call itself.
-      trap - INT TERM EXIT
-
-      if [ -n "$beacon_vm_pid" ]; then
-        # A leading '-' makes kill signal that process group, not just that PID.
-        kill -- "-$beacon_vm_pid" 2>/dev/null || true
-        wait "$beacon_vm_pid" 2>/dev/null || true
+      if grep -R "I'm empty and in plain text right now" .; then
+        echo "Failed to replace secrets file, fix the templating."
+        exit 1
       fi
 
-      if [ "$remove_tmpdir" = true ]; then
-        rm -rf -- "$tmpdir"
+      # Using a git repo here allows to only copy in the nix store non temporary files.
+      # In particular, we avoid copying the disk*.qcow2 files.
+      git init
+      echo ".skarabox-tmp" > .gitignore
+      git add .
+      git config user.name "skarabox"
+      git config user.email "skarabox@skarabox.com"
+      git commit -m 'init repository'
+      ${nix} flake update --override-input skarabox ${../.} skarabox
+      git add flake.lock
+      git commit -m 'use local skarabox input'
+      ${nix} run .#myskarabox-gen-knownhosts-file --show-trace
+      git add ./myskarabox/known_hosts
+      git commit -m 'generate known hosts'
+
+      endgroup "Initialisation done"
+
+      if [ "$dataPool" = false ]; then
+        sed -i 's-enable = true-enable = false-' ./myskarabox/configuration.nix
+      fi
+      if [ "$rootDisk2" = true ]; then
+        sed -i 's-disk2 = null-disk2 = "/dev/nvme1n1"-' ./myskarabox/configuration.nix
       fi
 
-      exit "$status"
-    }
-    # Preserve the original exit status, and use conventional statuses for signals.
-    trap 'cleanup $?' EXIT
-    trap 'cleanup 130' INT
-    trap 'cleanup 143' TERM
+      group "Nix flake show"
+      ${nix} flake show
+      endgroup "Done nix flake show"
 
-    while getopts "gp:" o; do
-      case "''${o}" in
-        g)
-          graphic=
-          ;;
-        p)
-          tmpdir=''${OPTARG}
-          ;;
-        *)
-          echo "$0 [-p TEMPDIR] [-g]"
-          exit 1
-          ;;
-      esac
-    done
-    shift $((OPTIND-1))
+      e "Starting beacon VM."
 
-    if [ -z "$tmpdir" ]; then
-      group "Creating tmpdir"
-      tmpdir="$(mktemp -d)"
-      remove_tmpdir=true
-      e "Created temp dir at $tmpdir, will be cleaned up on exit or abort"
-      endgroup "Done creating tmpdir"
-    else
-      e "Using provided temp dir $tmpdir, it will not be cleaned up"
-    fi
-    cd "$tmpdir"
+      ${setsid} ${nix} run .#myskarabox-beacon-vm -- $graphic &
+      beacon_vm_pid=$!
 
-    group "Initialising template"
-    echo skarabox1234 | ${nix} run ${../.}#init -- -v -y -s
-    sed -i "s/\(ip =\) \"192.168.1.30\"/\1 \"127.0.0.1\"/" "flake.nix"
-    sed -i "s/\(system =\) \"x86_64-linux\"/\1 \"${system}\"/" "flake.nix"
-    if [ "$legacyNixpkgs" = true ]; then
-      sed -i "s/\(nixpkgs =\) .*;$/\1 null;/" "flake.nix"
-      sed -i "/inputs.selfhostblocks.nixosModules.default$/d" "flake.nix"
-    fi
-    sed -i "s/\(skarabox.sshPort =\) 2222/\1 $sshPort/" "./myskarabox/configuration.nix"
-    sed -i "s/\(skarabox.boot.sshPort =\) 2223/\1 $sshBootPort/" "./myskarabox/configuration.nix"
+      sleep 10
 
-    if grep -R "I'm empty and in plain text right now" .; then
-      echo "Failed to replace secrets file, fix the templating."
-      exit 1
-    fi
+      group "Starting ssh loop to figure out when beacon started."
+      e "You might see some flickering on the command line."
+      # We can't yet be strict on the host key check since the beacon
+      # initially has a random one.
+      while ! ${nix} run .#myskarabox-ssh -- -F none -o CheckHostIP=no -o StrictHostKeyChecking=no echo "connected"; do
+        sleep 5
+      done
+      endgroup "Beacon VM has started."
 
-    # Using a git repo here allows to only copy in the nix store non temporary files.
-    # In particular, we avoid copying the disk*.qcow2 files.
-    git init
-    echo ".skarabox-tmp" > .gitignore
-    git add .
-    git config user.name "skarabox"
-    git config user.email "skarabox@skarabox.com"
-    git commit -m 'init repository'
-    ${nix} flake update --override-input skarabox ${../.} skarabox
-    git add flake.lock
-    git commit -m 'use local skarabox input'
-    ${nix} run .#myskarabox-gen-knownhosts-file --show-trace
-    git add ./myskarabox/known_hosts
-    git commit -m 'generate known hosts'
+      group "Generating hardware config."
+      ${nix} run .#myskarabox-get-facter > ./myskarabox/facter.json
+      ${jq}/bin/jq < ./myskarabox/facter.json
+      git add ./myskarabox/facter.json
+      git commit -m 'generate hardware config'
+      endgroup "Generation succeeded."
 
-    endgroup "Initialisation done"
+      group "Starting installation on beacon VM."
+      ${nix} run .#myskarabox-install-on-beacon -- --no-substitute-on-destination
+      endgroup "Installation succeeded."
 
-    if [ "$dataPool" = false ]; then
-      sed -i 's-enable = true-enable = false-' ./myskarabox/configuration.nix
-    fi
-    if [ "$rootDisk2" = true ]; then
-      sed -i 's-disk2 = null-disk2 = "/dev/nvme1n1"-' ./myskarabox/configuration.nix
-    fi
+      group "Starting unlock loop to decrypt root dataset."
+      e "You might see some flickering on the command line."
+      while ! ${nix} run .#myskarabox-unlock -- -F none; do
+        sleep 5
+      done
+      endgroup "Decryption done."
 
-    group "Nix flake show"
-    ${nix} flake show
-    endgroup "Done nix flake show"
+      group "Starting ssh loop to figure out when VM has booted."
+      e "You might see some flickering on the command line."
+      while ! ${nix} run .#myskarabox-ssh -- -F none echo "connected"; do
+        sleep 5
+      done
+      endgroup "Beacon VM has started."
 
-    e "Starting beacon VM."
+      group "Checking password for skarabox user has been set."
+      hashedpwd="$(${nix} run .#sops -- decrypt --extract '["myskarabox"]["user"]["hashedPassword"]' ./myskarabox/secrets.yaml)"
+      ${nix} run .#myskarabox-ssh -- -F none sudo cat /etc/shadow | ${gnugrep}/bin/grep "$hashedpwd"
+      endgroup "Password has been set."
 
-    ${setsid} ${nix} run .#myskarabox-beacon-vm -- $graphic &
-    beacon_vm_pid=$!
+      group "Checking nixos users mapping is consistnet."
+      uidmap=$(${nix} run .#myskarabox-ssh -- -F none sudo cat /var/lib/nixos/uid-map)
+      gidmap=$(${nix} run .#myskarabox-ssh -- -F none sudo cat /var/lib/nixos/gid-map)
+      if [ -z "$uidmap" ]; then
+        echo "No uid map found"
+        exit 1
+      fi
+      if [ -z "$gidmap" ]; then
+        echo "No gid map found"
+        exit 1
+      fi
+      endgroup "We'll see later."
 
-    sleep 10
+      group "Rebooting to confirm we can connect after a reboot."
+      # We sleep first and run the whole script in the background
+      # to avoid a race condition where the VM reboots too fast
+      # and kills the ssh connection, resulting in the test failing.
+      # So this is all so we can disconnect first.
+      ${nix} run .#myskarabox-ssh -- -F none "(sleep 2 && sudo reboot)&"
+      endgroup "Rebooting in progress."
 
-    group "Starting ssh loop to figure out when beacon started."
-    e "You might see some flickering on the command line."
-    # We can't yet be strict on the host key check since the beacon
-    # initially has a random one.
-    while ! ${nix} run .#myskarabox-ssh -- -F none -o CheckHostIP=no -o StrictHostKeyChecking=no echo "connected"; do
-      sleep 5
-    done
-    endgroup "Beacon VM has started."
+      group "Starting unlock loop to decrypt root dataset."
+      e "You might see some flickering on the command line."
+      while ! ${nix} run .#myskarabox-unlock -- -F none; do
+        sleep 5
+      done
+      endgroup "Decryption done."
 
-    group "Generating hardware config."
-    ${nix} run .#myskarabox-get-facter > ./myskarabox/facter.json
-    ${jq}/bin/jq < ./myskarabox/facter.json
-    git add ./myskarabox/facter.json
-    git commit -m 'generate hardware config'
-    endgroup "Generation succeeded."
+      group "Starting ssh loop to figure out when VM has booted."
+      e "You might see some flickering on the command line."
+      while ! ${nix} run .#myskarabox-ssh -- -F none echo "connected"; do
+        sleep 5
+      done
+      endgroup "Beacon VM has started."
 
-    group "Starting installation on beacon VM."
-    ${nix} run .#myskarabox-install-on-beacon -- --no-substitute-on-destination
-    endgroup "Installation succeeded."
+      group "Checking password for skarabox user is still set."
+      ${nix} run .#myskarabox-ssh -- -F none sudo cat /etc/shadow | ${gnugrep}/bin/grep "$hashedpwd"
+      endgroup "Password has been set."
 
-    group "Starting unlock loop to decrypt root dataset."
-    e "You might see some flickering on the command line."
-    while ! ${nix} run .#myskarabox-unlock -- -F none; do
-      sleep 5
-    done
-    endgroup "Decryption done."
+      group "Checking nixos users mapping is consistnet."
+      uidmap2=$(${nix} run .#myskarabox-ssh -- -F none sudo cat /var/lib/nixos/uid-map)
+      gidmap2=$(${nix} run .#myskarabox-ssh -- -F none sudo cat /var/lib/nixos/gid-map)
 
-    group "Starting ssh loop to figure out when VM has booted."
-    e "You might see some flickering on the command line."
-    while ! ${nix} run .#myskarabox-ssh -- -F none echo "connected"; do
-      sleep 5
-    done
-    endgroup "Beacon VM has started."
+      if [ "$uidmap2" != "$uidmap" ]; then
+        echo "Uid map is not consistent, got first:"
+        echo "$uidmap"
+        echo "and then":
+        echo "$uidmap2"
+        exit 1
+      fi
 
-    group "Checking password for skarabox user has been set."
-    hashedpwd="$(${nix} run .#sops -- decrypt --extract '["myskarabox"]["user"]["hashedPassword"]' ./myskarabox/secrets.yaml)"
-    ${nix} run .#myskarabox-ssh -- -F none sudo cat /etc/shadow | ${gnugrep}/bin/grep "$hashedpwd"
-    endgroup "Password has been set."
+      if [ "$gidmap2" != "$gidmap" ]; then
+        echo "Gid map is not consistent, got first:"
+        echo "$gidmap"
+        echo "and then":
+        echo "$uidmap2"
+        exit 1
+      fi
 
-    group "Checking nixos users mapping is consistnet."
-    uidmap=$(${nix} run .#myskarabox-ssh -- -F none sudo cat /var/lib/nixos/uid-map)
-    gidmap=$(${nix} run .#myskarabox-ssh -- -F none sudo cat /var/lib/nixos/gid-map)
-    if [ -z "$uidmap" ]; then
-      echo "No uid map found"
-      exit 1
-    fi
-    if [ -z "$gidmap" ]; then
-      echo "No gid map found"
-      exit 1
-    fi
-    endgroup "We'll see later."
+      endgroup "Mapping is consistent."
 
-    group "Rebooting to confirm we can connect after a reboot."
-    # We sleep first and run the whole script in the background
-    # to avoid a race condition where the VM reboots too fast
-    # and kills the ssh connection, resulting in the test failing.
-    # So this is all so we can disconnect first.
-    ${nix} run .#myskarabox-ssh -- -F none "(sleep 2 && sudo reboot)&"
-    endgroup "Rebooting in progress."
+      group "Deploying with deploy-rs."
+      sed -i 's/inputs.skarabox.flakeModules.colmena/# inputs.skarabox.flakeModules.colmena/' ./flake.nix
+      ${nix} run .#deploy-rs -- --debug-logs --temp-path .tmp
+      sed -i 's/# inputs.skarabox.flakeModules.colmena/inputs.skarabox.flakeModules.colmena/' ./flake.nix
+      endgroup "Deploying with deploy-rs done."
 
-    group "Starting unlock loop to decrypt root dataset."
-    e "You might see some flickering on the command line."
-    while ! ${nix} run .#myskarabox-unlock -- -F none; do
-      sleep 5
-    done
-    endgroup "Decryption done."
+      group "Deploying with colmena."
+      sed -i 's/inputs.skarabox.flakeModules.deploy-rs/# inputs.skarabox.flakeModules.deploy-rs/' ./flake.nix
+      ${nix} run .#colmena apply --show-trace
+      sed -i 's/# inputs.skarabox.flakeModules.deploy-rs/inputs.skarabox.flakeModules.deploy-rs/' ./flake.nix
+      endgroup "Deploying with colmena done."
 
-    group "Starting ssh loop to figure out when VM has booted."
-    e "You might see some flickering on the command line."
-    while ! ${nix} run .#myskarabox-ssh -- -F none echo "connected"; do
-      sleep 5
-    done
-    endgroup "Beacon VM has started."
+      group "Checking password for skarabox user is still set."
+      ${nix} run .#myskarabox-ssh -- -F none sudo cat /etc/shadow | ${gnugrep}/bin/grep "$hashedpwd"
+      endgroup "Password has been set."
 
-    group "Checking password for skarabox user is still set."
-    ${nix} run .#myskarabox-ssh -- -F none sudo cat /etc/shadow | ${gnugrep}/bin/grep "$hashedpwd"
-    endgroup "Password has been set."
-
-    group "Checking nixos users mapping is consistnet."
-    uidmap2=$(${nix} run .#myskarabox-ssh -- -F none sudo cat /var/lib/nixos/uid-map)
-    gidmap2=$(${nix} run .#myskarabox-ssh -- -F none sudo cat /var/lib/nixos/gid-map)
-
-    if [ "$uidmap2" != "$uidmap" ]; then
-      echo "Uid map is not consistent, got first:"
-      echo "$uidmap"
-      echo "and then":
-      echo "$uidmap2"
-      exit 1
-    fi
-
-    if [ "$gidmap2" != "$gidmap" ]; then
-      echo "Gid map is not consistent, got first:"
-      echo "$gidmap"
-      echo "and then":
-      echo "$uidmap2"
-      exit 1
-    fi
-
-    endgroup "Mapping is consistent."
-
-    group "Deploying with deploy-rs."
-    sed -i 's/inputs.skarabox.flakeModules.colmena/# inputs.skarabox.flakeModules.colmena/' ./flake.nix
-    ${nix} run .#deploy-rs -- --debug-logs --temp-path .tmp
-    sed -i 's/# inputs.skarabox.flakeModules.colmena/inputs.skarabox.flakeModules.colmena/' ./flake.nix
-    endgroup "Deploying with deploy-rs done."
-
-    group "Deploying with colmena."
-    sed -i 's/inputs.skarabox.flakeModules.deploy-rs/# inputs.skarabox.flakeModules.deploy-rs/' ./flake.nix
-    ${nix} run .#colmena apply --show-trace
-    sed -i 's/# inputs.skarabox.flakeModules.deploy-rs/inputs.skarabox.flakeModules.deploy-rs/' ./flake.nix
-    endgroup "Deploying with colmena done."
-
-    group "Checking password for skarabox user is still set."
-    ${nix} run .#myskarabox-ssh -- -F none sudo cat /etc/shadow | ${gnugrep}/bin/grep "$hashedpwd"
-    endgroup "Password has been set."
-
-    group "Connecting and shutting down"
-    ${nix} run .#myskarabox-ssh -- -F none sudo shutdown
-    endgroup "Shutdown complete."
-  '';
+      group "Connecting and shutting down"
+      ${nix} run .#myskarabox-ssh -- -F none sudo shutdown
+      endgroup "Shutdown complete."
+    '';
 in
 {
   oneOSnoData = templateTest {


### PR DESCRIPTION
Match SelfHostBlocks by exposing pkgs.nixfmt-tree as the flake formatter and checking all Nix files in CI. Apply the formatter once so the new check passes, and remove the unreferenced empty tests/upgrades.nix file that nixfmt cannot parse.

Tested with: find . -name '*.nix' | nix fmt -- --ci

Tested with: nix flake check