### PR TITLE
Retry initrd SSH in unlock commands

### DIFF
--- a/flakeModules/default.nix
+++ b/flakeModules/default.nix
@@ -662,6 +662,7 @@ in
               name = "unlock";
 
               runtimeInputs = [
+                pkgs.coreutils
                 sops
                 boot-ssh
               ];
@@ -670,7 +671,21 @@ in
               # so this path must not allocate a TTY that could echo the passphrase.
               text = ''
                 root_passphrase="$(sops decrypt --extract "${cfg'.secretsRootPassphrasePath}" "${cfg'.secretsFilePath}")"
-                printf '%s\n' "$root_passphrase" | boot-ssh -T "$@"
+                timeout=300
+                started_at=$SECONDS
+                deadline=$((started_at + timeout))
+
+                # QEMU can accept a forwarded TCP connection before initrd SSH sends
+                # its banner, which ConnectionAttempts alone does not retry.
+                while ! printf '%s\n' "$root_passphrase" | boot-ssh -T -o ConnectionAttempts=10 "$@"; do
+                  if ((SECONDS >= deadline)); then
+                    printf 'Timed out waiting for initrd SSH.\n' >&2
+                    exit 1
+                  fi
+
+                  printf 'Initrd SSH is not ready; retrying (%d/%d seconds elapsed).\n' "$((SECONDS - started_at))" "$timeout" >&2
+                  sleep 1
+                done
               '';
             };
           in

--- a/tests/static.nix
+++ b/tests/static.nix
@@ -138,9 +138,7 @@
 
     group "Starting unlock loop to decrypt root dataset."
     e "You might see some flickering on the command line."
-    while ! ${nix} run .#myskarabox-unlock -- -F none; do
-      sleep 5
-    done
+    ${nix} run .#myskarabox-unlock -- -F none
     endgroup "Decryption done."
 
     group "Starting ssh loop to figure out when VM has booted."

--- a/tests/variants.nix
+++ b/tests/variants.nix
@@ -174,9 +174,7 @@ let
 
       group "Starting unlock loop to decrypt root dataset."
       e "You might see some flickering on the command line."
-      while ! ${nix} run .#myskarabox-unlock -- -F none; do
-        sleep 5
-      done
+      ${nix} run .#myskarabox-unlock -- -F none
       endgroup "Decryption done."
 
       group "Starting ssh loop to figure out when VM has booted."
@@ -214,9 +212,7 @@ let
 
       group "Starting unlock loop to decrypt root dataset."
       e "You might see some flickering on the command line."
-      while ! ${nix} run .#myskarabox-unlock -- -F none; do
-        sleep 5
-      done
+      ${nix} run .#myskarabox-unlock -- -F none
       endgroup "Decryption done."
 
       group "Starting ssh loop to figure out when VM has booted."


### PR DESCRIPTION
Allow <host>-unlock to be started as soon as a reboot is requested. Use OpenSSH connection attempts while the initrd port is unavailable and retry the complete SSH command because a forwarded port can accept a connection before the SSH server sends its banner.\n\nMake VM tests call unlock once so they exercise the generated helper's bounded retry behavior instead of supplying their own infinite loops.